### PR TITLE
Pass token to Codecov upload script

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -31,7 +31,7 @@ steps:
   displayName: Run tests
   workingDirectory: $(Pipeline.Workspace)/src
 
-- bash: bash <(curl -s https://codecov.io/bash) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
+- bash: bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
   displayName: Publish coverage stats
   continueOnError: true
   workingDirectory: $(Pipeline.Workspace)/src


### PR DESCRIPTION
Supposedly this isn't required (see [the Codecov docs](https://docs.codecov.io/docs/about-the-codecov-bash-uploader#upload-token)) but in practice, it seems to be necessary (see [this example Azure Pipelines build](https://dev.azure.com/azure-dials/dials/_build/results?buildId=2917&view=logs&j=91294a66-ce32-5b22-4cb3-513657922622&t=7ed40b7d-8922-58f8-dac6-7fbd4666a9b6&l=51)).