### PR TITLE
Bug fixes from real-world testing

### DIFF
--- a/src/tristan/__init__.py
+++ b/src/tristan/__init__.py
@@ -26,7 +26,10 @@ except ImportError:
 
     ArrayLike = np.ndarray
 
-clock_frequency = 6.4e8
+
+ureg = pint.UnitRegistry()
+
+clock_frequency = ureg.Quantity(6.4e8, "Hz").to_compact()
 
 # Translations of the basic cue_id messages.
 padding = 0
@@ -142,7 +145,7 @@ def seconds(timestamp: ArrayLike, reference: ArrayLike = 0) -> ArrayLike:
     Returns:
         The difference between the two timestamps in seconds.
     """
-    return pint.Quantity((timestamp - reference) / clock_frequency, "s").to_compact()
+    return ((timestamp - reference) / clock_frequency).to_base_units().to_compact()
 
 
 def pixel_index(location: ArrayLike, image_size: Tuple[int, int]) -> ArrayLike:

--- a/src/tristan/command_line/__init__.py
+++ b/src/tristan/command_line/__init__.py
@@ -1,12 +1,19 @@
 """General utilities for the command-line tools."""
 
 import argparse
+from typing import SupportsFloat, Union
 
-import pint
-
-from .. import __version__
+from .. import __version__, ureg
 
 __all__ = ("version_parser", "input_parser", "image_output_parser", "exposure_parser")
+
+
+Quantity, Unit = ureg.Quantity, ureg.Unit
+
+
+def default_unit(quantity: Union[Quantity, SupportsFloat], unit: str = "s") -> Quantity:
+    quantity = Quantity(quantity)
+    return quantity * Unit(unit) if quantity.dimensionless else quantity
 
 
 version_parser = argparse.ArgumentParser(add_help=False)
@@ -60,6 +67,6 @@ group.add_argument(
     help="Duration of each image.  This will be used to calculate the number of "
     "images.  Specify a value with units like '--exposure-time .5ms', '-e 500µs' or "
     "'-e 500us'.",
-    type=pint.Quantity,
+    type=default_unit,
 )
 group.add_argument("-n", "--num-images", help="Number of images.", type=int)

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -290,6 +290,7 @@ parser_pump_probe.add_argument(
     "--trigger-type",
     help="The type of trigger signal used as the pump pulse marker.",
     choices=triggers.keys(),
+    required=True,
 )
 parser_pump_probe.set_defaults(func=pump_probe_cli)
 

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -63,10 +63,9 @@ def determine_image_size(data_dir: Path, root: str) -> Tuple[int, int]:
 def exposure(
     start: int, end: int, exposure_time: pint.Quantity = None, num_images: int = None
 ):
-    freq = pint.Quantity(clock_frequency, "Hz")
     if exposure_time:
         exposure_time = exposure_time.to_base_units().to_compact()
-        exposure_cycles = (exposure_time * freq).to_base_units().magnitude
+        exposure_cycles = (exposure_time * clock_frequency).to_base_units().magnitude
         num_images = int((end - start) // exposure_cycles)
     else:
         # Because they are expected to be mutually exclusive, if there is no

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -217,6 +217,7 @@ def pump_probe_cli(args):
         )
 
         # Measure the event time as time elapsed since the most recent trigger signal.
+        trigger_times = da.from_array(trigger_times)
         data[event_time_key] = data[event_time_key].astype(np.int64)
         data[event_time_key] -= trigger_times[
             da.digitize(data[event_time_key], trigger_times) - 1


### PR DESCRIPTION
- Make sure `images pp` can handle large arrays.  Previously, it would attempt to allocate memory for a 64-bit integer for each event, which could very easily exceed available memory.  Fixing this simply involved defining a Dask array from a NumPy array.
- Make sure `images pp` demands the `--trigger-type`/`-t` option.
- Handle units of time and frequency more gracefully, including imposing a default unit of seconds for exposure time if the user does not specify units.