### PR TITLE
Rename nexgen directory fix

### DIFF
--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -14,9 +14,9 @@ from dask.diagnostics import ProgressBar
 from hdf5plugin import Bitshuffle
 
 try:
-    from nexgen.copy import CopyTristanNexus
-except ModuleNotFoundError:
     from nexgen.nxs_copy import CopyTristanNexus  # nexgen version >= 0.4.8
+except ModuleNotFoundError:
+    from nexgen.copy import CopyTristanNexus
 
 from .. import (
     clock_frequency,

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -12,7 +12,10 @@ import pint
 from dask import array as da
 from dask.diagnostics import ProgressBar
 from hdf5plugin import Bitshuffle
-from nexgen.nxs_copy import CopyTristanNexus
+try:
+    from nexgen.copy import CopyTristanNexus
+except ModuleNotFoundError:
+    from nexgen.nxs_copy import CopyTristanNexus
 
 from .. import (
     clock_frequency,

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -12,10 +12,11 @@ import pint
 from dask import array as da
 from dask.diagnostics import ProgressBar
 from hdf5plugin import Bitshuffle
+
 try:
     from nexgen.copy import CopyTristanNexus
 except ModuleNotFoundError:
-    from nexgen.nxs_copy import CopyTristanNexus
+    from nexgen.nxs_copy import CopyTristanNexus  # nexgen version >= 0.4.8
 
 from .. import (
     clock_frequency,

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -12,7 +12,7 @@ import pint
 from dask import array as da
 from dask.diagnostics import ProgressBar
 from hdf5plugin import Bitshuffle
-from nexgen.copy import CopyTristanNexus
+from nexgen.nxs_copy import CopyTristanNexus
 
 from .. import (
     clock_frequency,


### PR DESCRIPTION
I had to rename the directory in nexgen for the copying functions, here I call the new correct one