### PR TITLE
Add a context manager for reading LATRD data

### DIFF
--- a/src/tristan/command_line/cues.py
+++ b/src/tristan/command_line/cues.py
@@ -1,13 +1,10 @@
 """Summarise the cue messages in Tristan data."""
 
 import argparse
-from contextlib import ExitStack
 
-import h5py
 import numpy as np
-from dask import array as da
 
-from .. import cue_id_key, cue_keys, cue_time_key, cues, reserved, seconds
+from .. import cue_id_key, cue_keys, cue_time_key, cues, latrd_data, reserved, seconds
 from ..data import data_files, find_input_file_name
 from . import input_parser, version_parser
 
@@ -23,12 +20,7 @@ def main(args=None):
     data_dir, root = find_input_file_name(args.input_file)
     raw_files, _ = data_files(data_dir, root)
 
-    with ExitStack() as stack:
-        files = [stack.enter_context(h5py.File(f, "r")) for f in raw_files]
-        data = {
-            key: da.concatenate([f[key] for f in files]).rechunk() for key in cue_keys
-        }
-
+    with latrd_data(raw_files, keys=cue_keys) as data:
         relevant = (data[cue_id_key] > 0) & (data[cue_id_key] != reserved)
         cue_ids = data[cue_id_key][relevant].compute()
         cue_times = data[cue_time_key][relevant].compute()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,49 @@
+"""Tests of utilities for handling LATRD Tristan data."""
+
+import h5py
+import numpy as np
+from dask.array import assert_eq
+from pytest import fixture
+
+from tristan import cue_keys, event_keys, latrd_data
+
+# A set of arbitrary offsets to distinguish the dummy data sets from one another.
+offsets = dict(zip(cue_keys + event_keys, range(0, 500, 100)))
+
+
+@fixture(scope="session")
+def dummy_latrd_data(tmp_path_factory):
+    """
+    Construct a temporary directory containing dummy LATRD data.
+
+    The data are spread across several files, in the manner of a LATRD data
+    collection, with each file having an entry for each of the LATRD data keys.
+    """
+    tmp_path = tmp_path_factory.mktemp("dummy_data", numbered=False)
+    ranges = np.arange(15).reshape(3, 5)
+    for i, values in enumerate(ranges):
+        with h5py.File(tmp_path / f"dummy_{i:06d}.h5", "w") as f:
+            for key, offset in offsets.items():
+                f.create_dataset(key, data=values + offset)
+
+    return tmp_path
+
+
+def test_latrd_data_default_keys(dummy_latrd_data):
+    """
+    Test that the latrd_data context manager correctly reconstructs the dummy data.
+
+    Construct a LATRD data dictionary from the dummy data files and check that there
+    is an entry for each of the default keys, and that each entry has the expected
+    values.
+    """
+    with latrd_data(sorted(dummy_latrd_data.iterdir())) as data:
+        assert set(data.keys()) == set(cue_keys + event_keys)
+        for key, offset in offsets.items():
+            assert_eq(data[key], np.arange(15) + offset)
+
+
+def test_latrd_data_specified_keys(dummy_latrd_data):
+    """Test that the latrd_data context manager reads only the specified keys."""
+    with latrd_data(sorted(dummy_latrd_data.iterdir()), cue_keys) as data:
+        assert set(data.keys()) == set(cue_keys)


### PR DESCRIPTION
Given a list of file names, read data from multiple files into a single dictionary of data.  The keys are the LATRD data keys (`cue_id`, `cue_timestamp_zero`, `event_id`, `event_time_offset` & `event_energy`), or a subset thereof, and each value is a single Dask array containing the corresponding LATRD data sets from all of the files, concatenated into a single array.

This structure makes it easy to perform calculations on the entire data set without needing to know the details of how the data are arranged on disk, as well as handling the opening and closing of an arbitrary number of `h5py.File` objects tidily.