### PR TITLE
Migrate to new pre-compiled Codecov uploader

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -57,7 +57,9 @@ stages:
         mkdir -p dist/pypi
         shopt -s extglob
         mv -v dist/!(pypi) dist/pypi
-        git archive HEAD | gzip > dist/repo-source.tar.gz
+        git archive HEAD > dist/repo-source.tar
+        tar -rf dist/repo-source.tar .git
+        gzip dist/repo-source.tar
         ls -laR dist
       displayName: Build python package
 

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -57,9 +57,7 @@ stages:
         mkdir -p dist/pypi
         shopt -s extglob
         mv -v dist/!(pypi) dist/pypi
-        git archive HEAD > dist/repo-source.tar
-        tar -rf dist/repo-source.tar .git
-        gzip dist/repo-source.tar
+        git archive HEAD | gzip > dist/repo-source.tar.gz
         ls -laR dist
       displayName: Build python package
 

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -31,7 +31,10 @@ steps:
   displayName: Run tests
   workingDirectory: $(Pipeline.Workspace)/src
 
-- bash: bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
+- bash: |
+    curl -Os https://uploader.codecov.io/latest/linux/codecov
+    chmod +x codecov
+    ./codecov -n "Python $(PYTHON_VERSION) $(Agent.OS)"
   displayName: Publish coverage stats
   continueOnError: true
   workingDirectory: $(Pipeline.Workspace)/src

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -34,7 +34,7 @@ steps:
 - bash: |
     curl -Os https://uploader.codecov.io/latest/linux/codecov
     chmod +x codecov
-    ./codecov -n "Python $(PYTHON_VERSION) $(Agent.OS)"
+    ./codecov -t $(CODECOV_TOKEN) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
   displayName: Publish coverage stats
   continueOnError: true
   workingDirectory: $(Pipeline.Workspace)/src

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -34,7 +34,7 @@ steps:
 - bash: |
     curl -Os https://uploader.codecov.io/latest/linux/codecov
     chmod +x codecov
-    ./codecov -C $(Build.SourceVersion) -t $(CODECOV_TOKEN) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
+    ./codecov -B $(Build.SourceBranchName) -C $(Build.SourceVersion) -t $(CODECOV_TOKEN) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
   displayName: Publish coverage stats
   continueOnError: true
   workingDirectory: $(Pipeline.Workspace)/src

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -34,7 +34,7 @@ steps:
 - bash: |
     curl -Os https://uploader.codecov.io/latest/linux/codecov
     chmod +x codecov
-    ./codecov -t $(CODECOV_TOKEN) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
+    ./codecov -C $(Build.SourceVersion) -t $(CODECOV_TOKEN) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
   displayName: Publish coverage stats
   continueOnError: true
   workingDirectory: $(Pipeline.Workspace)/src


### PR DESCRIPTION
- Codecov's Bash uploader is deprecated, see
  https://docs.codecov.com/docs/about-the-codecov-bash-uploader
- Use the new pre-compiled uploader instead, see
  https://docs.codecov.com/docs/codecov-uploader
- ~Experiment with removing the '-t' flag, as it ought not to be
  necessary for uploading code coverage statistics from this public
  repo.~