### PR TITLE
Apply memory back-pressure to multi-image binning

### DIFF
--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -73,13 +73,12 @@ def make_images(
     if num_images > 1:
         image_indices = da.digitize(event_times, bins) - 1
 
-        image_indices = [
-            image_indices == image_number for image_number in range(num_images)
-        ]
         images = da.stack(
             [
-                da.bincount(event_locations[indices], minlength=mul(*image_size))
-                for indices in image_indices
+                da.bincount(
+                    event_locations[image_indices == i], minlength=mul(*image_size)
+                )
+                for i in range(num_images)
             ]
         )
     else:

--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -69,19 +69,13 @@ def make_images(
     event_locations = pixel_index(event_locations, image_size)
 
     num_images = len(bins) - 1
+    pixels_per_image = mul(*image_size)
 
     if num_images > 1:
         image_indices = da.digitize(event_times, bins) - 1
-
-        images = da.stack(
-            [
-                da.bincount(
-                    event_locations[image_indices == i], minlength=mul(*image_size)
-                )
-                for i in range(num_images)
-            ]
-        )
+        event_locations = event_locations + image_indices * pixels_per_image
+        images = da.bincount(event_locations, minlength=num_images * pixels_per_image)
     else:
-        images = da.bincount(event_locations, minlength=mul(*image_size))
+        images = da.bincount(event_locations, minlength=pixels_per_image)
 
     return images.astype(np.uint32).reshape(num_images, *image_size)

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -160,7 +160,7 @@ def save_multiple_images(
     print("\nTransferring the images to the output file.")
     store = zarr.DirectoryStore(intermediate)
     with h5py.File(output_file, write_mode) as f:
-        zarr.copy(zarr.open(store), f, "/", **Bitshuffle())
+        zarr.copy_all(zarr.open(store), f, **Bitshuffle())
 
     # Delete the Zarr store.
     store.clear()

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -140,6 +140,8 @@ def save_multiple_images(
     not serialisable.  To work around this issue, the data are first stored to a Zarr
     DirectoryStore, then copied to the final HDF5 file and the Zarr store deleted.
 
+    Multithreading is used, as the calculation is assumed to be I/O bound.
+
     Args:
         array:  A Dask array to be calculated and stored.
         output_file:  Path to the output HDF5 file.
@@ -147,6 +149,7 @@ def save_multiple_images(
     """
     intermediate = str(output_file.parent / f"{output_file.stem}.zarr")
 
+    # Use threads, rather than processes.
     with Client(processes=False):
         # Overwrite any pre-existing Zarr storage.  Don't compute immediately but
         # return the Array object so we can compute it with a progress bar.

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -42,9 +42,6 @@ from . import (
     version_parser,
 )
 
-# from numcodecs.blosc import Blosc, BITSHUFFLE
-
-
 triggers = {
     "TTL-rising": ttl_rising,
     "TTL-falling": ttl_falling,

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -133,9 +133,10 @@ def save_multiple_images(
     than the available amount of memory.  Using the distributed scheduler avoids this
     problem.
 
-    The distributed scheduler cannot write directly to HDF5 files because they are
-    not serialisable.  To work around this issue, the data are first stored to a Zarr
-    DirectoryStore, then copied to the final HDF5 file and the Zarr store deleted.
+    The distributed scheduler cannot write directly to HDF5 files because h5py.File
+    objects are not serialisable.  To work around this issue, the data are first
+    stored to a Zarr DirectoryStore, then copied to the final HDF5 file and the Zarr
+    store deleted.
 
     Multithreading is used, as the calculation is assumed to be I/O bound.
 


### PR DESCRIPTION
Use the Dask distributed scheduler, to control greedy workers and prevent them from attempting to allocate more memory than is available.

Fixes #20.  See that issue for details.