### PR TITLE
Improve performance of image binning

### DIFF
--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -6,6 +6,7 @@ from typing import Dict, Tuple
 
 import numpy as np
 from dask import array as da
+from dask.distributed import progress
 from numpy.typing import ArrayLike
 
 from .data import (
@@ -18,7 +19,7 @@ from .data import (
 )
 
 
-def find_start_end(data: Dict[str, da.Array]) -> (int, int):
+def find_start_end(data: Dict[str, da.Array], distributed: bool = False) -> (int, int):
     """
     Find the shutter open and shutter close timestamps.
 
@@ -27,13 +28,23 @@ def find_start_end(data: Dict[str, da.Array]) -> (int, int):
                and Dask arrays as values).  Must contain one entry for cue id
                messages and one for cue timestamps.  The two arrays are assumed
                to have the same length.
+        distributed:  Whether the computation uses the Dask distributed scheduler,
+                      in which case a progress bar will be displayed.
 
     Returns:
         The shutter open and shutter close timestamps, in clock cycles.
     """
     start_time = first_cue_time(data, shutter_open)
     end_time = first_cue_time(data, shutter_close)
-    return da.compute(start_time, end_time)
+
+    # If we are using the distributed scheduler (for multiple images), show progress.
+    if distributed:
+        print("\nFinding detector shutter open and close times.")
+        progress([start_time.persist(), end_time.persist()])
+    start_time, end_time = da.compute(start_time, end_time)
+    print("")
+
+    return start_time, end_time
 
 
 def make_images(
@@ -64,8 +75,8 @@ def make_images(
     event_locations = data[event_location_key]
 
     valid_events = (bins[0] <= event_times) & (event_times < bins[-1])
-    event_times = event_times[valid_events]
-    event_locations = event_locations[valid_events]
+    event_times = event_times[valid_events].compute_chunk_sizes()
+    event_locations = event_locations[valid_events].compute_chunk_sizes()
     event_locations = pixel_index(event_locations, image_size)
 
     num_images = len(bins) - 1
@@ -73,16 +84,25 @@ def make_images(
     if num_images > 1:
         # We cannot perform a single bincount of the entire data set because that
         # would require allocating enough memory for the entire image stack.
+
+        # Find the index of the image to which each event belongs.
         image_indices = da.digitize(event_times, bins) - 1
 
-        images = da.stack(
-            [
-                da.bincount(
-                    event_locations[image_indices == i], minlength=mul(*image_size)
-                )
-                for i in range(num_images)
+        (images_in_block,) = da.compute(map(np.unique, image_indices.blocks))
+
+        # Construct a stack of images using dask.array.bincount.
+        images = []
+        for i in range(num_images):
+            # When searching for events with a given image index, we already know we
+            # can exclude some blocks and thereby save some computation time.
+            contains_index = [i in indices for indices in images_in_block]
+
+            image_events = event_locations.blocks[contains_index][
+                image_indices.blocks[contains_index] == i
             ]
-        )
+            images.append(da.bincount(image_events, minlength=mul(*image_size)))
+
+        images = da.stack(images)
     else:
         images = da.bincount(event_locations, minlength=mul(*image_size))
 

--- a/src/tristan/data.py
+++ b/src/tristan/data.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from typing import Dict, Iterable, Optional, Tuple, Union
 
 import h5py
-from pint import Quantity
-from dask import array as da, config
-import numpy as np
+from dask import array as da
+from dask import config
 from numpy.typing import ArrayLike
+from pint import Quantity
 
 from . import clock_frequency
 

--- a/src/tristan/data.py
+++ b/src/tristan/data.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from typing import Dict, Iterable, Optional, Tuple, Union
 
 import h5py
-import pint
-from dask import array as da
+from pint import Quantity
+from dask import array as da, config
+import numpy as np
 from numpy.typing import ArrayLike
 
 from . import clock_frequency
@@ -87,7 +88,9 @@ def latrd_data(
 
     The yielded dictionary has an entry for each of the specified LATRD data keys.
     Each key must be a valid LATRD data key and the corresponding value is a Dask
-    array containing the corresponding LATRD data from all the raw data files.
+    array containing the corresponding LATRD data from all the raw data files,
+    rechunked into blocks approximately the size of the default Dask array chunk
+    size, but with chunk boundaries aligned with HDF5 data set chunk boundaries.
 
     Args:
         raw_file_paths:  The paths of the raw LATRD data files.
@@ -97,9 +100,41 @@ def latrd_data(
         A dictionary of LATRD data keys and arrays of the corresponding data.
     """
     with ExitStack() as stack:
-        files = [stack.enter_context(h5py.File(path, "r")) for path in raw_file_paths]
+        files = [
+            stack.enter_context(h5py.File(path, "r", swmr=True))
+            for path in raw_file_paths
+        ]
 
-        yield {key: da.concatenate([f[key] for f in files]).rechunk() for key in keys}
+        target_size_bytes = int(Quantity(config.get("array.chunk-size")).m_as("bytes"))
+
+        data = {}
+        for key in keys:
+            data_sets = [f[key] for f in files]
+
+            # The optimal number of data per Dask chunk.
+            target_size = target_size_bytes // data_sets[0].dtype.itemsize
+
+            # Try to aggregate the input data into the fewest possible Dask chunks.
+            chunks = []
+            for d in data_sets:
+                # If this input data set will fit into the current chunk, add it.
+                if chunks and chunks[-1] + d.size <= target_size:
+                    chunks[-1] += d.size
+                # If the current chunk is full (or the chunks list is empty), add this
+                # data set to the next chunk.
+                elif d.size <= target_size:
+                    chunks.append(d.size)
+                # If this data set is larger than the max Dask chunk size, split it
+                # along the HDF5 data set chunk boundaries and put the pieces in
+                # separate Dask chunks.
+                else:
+                    n_whole_chunks, remainder = divmod(d.size, target_size)
+                    dask_chunk_size = target_size // d.chunks[0] * d.chunks[0]
+                    chunks += [dask_chunk_size] * n_whole_chunks + [remainder]
+
+            data[key] = da.concatenate(data_sets).rechunk(chunks)
+
+        yield data
 
 
 def first_cue_time(data: Dict[str, da.Array], message: int) -> Optional[da.Array]:
@@ -143,7 +178,7 @@ def cue_times(data: Dict[str, da.Array], message: int) -> da.Array:
     return da.unique(data[cue_time_key][index])
 
 
-def seconds(timestamp: int, reference: int = 0) -> pint.Quantity:
+def seconds(timestamp: int, reference: int = 0) -> Quantity:
     """
     Convert a Tristan timestamp to seconds, measured from a given reference timestamp.
 


### PR DESCRIPTION
- Play nicer with NFS systems, set more generous connection timeouts.
- Keep at least one CPU spare for garbage collection.
- Use the Dask client context manager at the top level.
- Use SWMR mode to read data.
- Be more prescriptive in delineating Dask chunks.  Set the chunk  boundaries so as to minimise the splitting of input data sets across  Dask chunks.
- Use the LATRD data context manager more atomically.  Do not construct  the Dask data arrays until they are needed, and close the data files  sooner when we are done with them.
- Use the distributed scheduler to find shutter times.  This allows  better user feedback with a meaningful progress bar.  It doesn't seem to have a significant performance penalty.  In fact, some informal testing suggests it may be slightly better.
- Improve binning of large data with many chunks.
  Some chunks of the event data will not contain events from every image in the image stack.  This may happen when a large data set (relative to the size of memory), having a large number of chunks, is binned to a large number of images.  In these circumstances, much computation time is wasted searching needlessly for the existence of every image index within every block of data.  Some of this time can be saved by identifying up front the subset of image index values present in each block and searching that block only for events with image indices within that subset.