### PR TITLE
Multi-sequence pump-probe binning

### DIFF
--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -42,7 +42,7 @@ def find_start_end(data: Dict[str, da.Array], distributed: bool = False) -> (int
         print("Finding detector shutter open and close times.")
         progress([start_time.persist(), end_time.persist()])
     start_time, end_time = da.compute(start_time, end_time)
-    print("")
+    print()
 
     return start_time, end_time
 

--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -39,7 +39,7 @@ def find_start_end(data: Dict[str, da.Array], distributed: bool = False) -> (int
 
     # If we are using the distributed scheduler (for multiple images), show progress.
     if distributed:
-        print("\nFinding detector shutter open and close times.")
+        print("Finding detector shutter open and close times.")
         progress([start_time.persist(), end_time.persist()])
     start_time, end_time = da.compute(start_time, end_time)
     print("")

--- a/src/tristan/command_line/__init__.py
+++ b/src/tristan/command_line/__init__.py
@@ -348,5 +348,5 @@ group.add_argument(
     type=units_of_time,
 )
 group.add_argument(
-    "-c", "--sequence-count", help="Number of image sequences.", type=positive_int
+    "-x", "--num-sequences", help="Number of image sequences.", type=positive_int
 )

--- a/src/tristan/command_line/__init__.py
+++ b/src/tristan/command_line/__init__.py
@@ -127,7 +127,8 @@ def check_multiple_output_files(
         if not force and exists:
             sys.exit(
                 f"The following output files already exist:\n\t"
-                "\n\t".join(map(str, exists)) + "\n"
+                + "\n\t".join(map(str, exists))
+                + "\n"
                 "Use '-f' to override, "
                 "or specify a different output file path with '-o'."
             )

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -403,9 +403,10 @@ def multiple_sequences_cli(args):
     bins = np.linspace(start, end, num_images + 1, dtype=np.uint64)
 
     print(
-        f"Binning events into {num_images} images with an exposure time of "
-        f"{exposure_time:~.3g} according to the time elapsed since the most recent "
-        f"'{cues[trigger_type]}' signal."  # TODO: mention number, etc., of intervals
+        f"Binning events into {num_intervals} sequences, each of {num_images} "
+        f"images with an exposure time of {exposure_time:~.3g}, corresponding to "
+        f"successive pump-probe delay intervals of {interval_time:~.3g}, with the "
+        f"pump marked by a '{cues[trigger_type]}' signal. "
     )
 
     trigger_times = da.from_array(trigger_times)

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -446,7 +446,7 @@ def multiple_sequences_cli(args):
                 write_mode=write_mode,
             )
 
-        output_nexus = out_file_pattern.with_ext(".nxs")
+        output_nexus = out_file_pattern.with_suffix(".nxs")
     else:
         output_nexus = None
 

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -149,7 +149,7 @@ def save_multiple_images(
         write_mode:  HDF5 file opening mode.  See :class:`h5py.File`.
     """
     # Set a more generous connection timeout than the default 30s.
-    dask.config.set(
+    with dask.config.set(
         {
             "distributed.comm.timeouts.connect": "60s",
             "distributed.comm.timeouts.tcp": "60s",
@@ -157,25 +157,24 @@ def save_multiple_images(
             "distributed.scheduler.idle-timeout": "600s",
             "distributed.scheduler.locks.lease-timeout": "60s",
         }
-    )
+    ):
+        intermediate = str(output_file.parent / f"{output_file.stem}.zarr")
 
-    intermediate = str(output_file.parent / f"{output_file.stem}.zarr")
+        # Overwrite any pre-existing Zarr storage.  Don't compute immediately but
+        # return the Array object so we can compute it with a progress bar.
+        method = {"overwrite": True, "compute": False, "return_stored": True}
+        # Prepare to save the calculated images to the intermediate Zarr store.
+        array = array.to_zarr(intermediate, component="data", **method)
+        # Compute the Array and store the values, using a progress bar.
+        progress(array.persist())
 
-    # Overwrite any pre-existing Zarr storage.  Don't compute immediately but
-    # return the Array object so we can compute it with a progress bar.
-    method = {"overwrite": True, "compute": False, "return_stored": True}
-    # Prepare to save the calculated images to the intermediate Zarr store.
-    array = array.to_zarr(intermediate, component="data", **method)
-    # Compute the Array and store the values, using a progress bar.
-    progress(array.persist())
+        print("\nTransferring the images to the output file.")
+        store = zarr.DirectoryStore(intermediate)
+        with h5py.File(output_file, write_mode) as f:
+            zarr.copy_all(zarr.open(store), f, **Bitshuffle())
 
-    print("\nTransferring the images to the output file.")
-    store = zarr.DirectoryStore(intermediate)
-    with h5py.File(output_file, write_mode) as f:
-        zarr.copy_all(zarr.open(store), f, **Bitshuffle())
-
-    # Delete the Zarr store.
-    store.clear()
+        # Delete the Zarr store.
+        store.clear()
 
 
 def multiple_images_cli(args):
@@ -310,6 +309,10 @@ def pump_probe_cli(args):
         save_multiple_images(images, output_file, write_mode)
 
     print(f"Images written to\n\t{output_nexus or output_file}")
+
+
+def multiple_sequences_cli(args):
+    pass
 
 
 parser = argparse.ArgumentParser(description=__doc__, parents=[version_parser])


### PR DESCRIPTION
Add a tool `images sequences` to bin a data collection that contains pump trigger signals into several sequences of images, each sequence corresponding to a given pump-probe delay interval. The sequences are output in order of increasing pump-probe delay.

Closes #25.