### PR TITLE
Change to copy functions for NeXus file.

### DIFF
--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -320,7 +320,6 @@ def pump_probe_cli(args):
     if input_nexus.exists():
         try:
             # Write output NeXus file if we have an input NeXus file.
-            # As it is not a scan, the function used for single image does the job.
             output_nexus = CopyTristanNexus.single_image_nexus(
                 output_file, input_nexus, write_mode=write_mode
             )


### PR DESCRIPTION
As discussed, for a pump-probe experiment I am substituting pump_probe_nexus with single_image_nexus. As they do exactly the same thing, pump_probe is redundant and will be removed from the next version of nexgen. 