### PR TITLE
Print some quantities more prettily

### DIFF
--- a/src/tristan/command_line/cues.py
+++ b/src/tristan/command_line/cues.py
@@ -46,9 +46,9 @@ def main(args=None):
 {cue_description}:
 Found {cue_times_sel.size} instances.
 Found {deduplicated.size} de-duplicated instances with
-\tsmallest time difference: {min_diff} cycles ({seconds(min_diff):~.3g}),
-\tlargest time difference: {max_diff} cycles ({seconds(max_diff):~.3g}),
-\tmean time difference: {avg_diff:.2f} cycles ({seconds(avg_diff):~.3g})."""
+\tsmallest time difference: {min_diff} cycles ({seconds(min_diff):.3g~#P}),
+\tlargest time difference: {max_diff} cycles ({seconds(max_diff):.3g~#P}),
+\tmean time difference: {avg_diff:.2f} cycles ({seconds(avg_diff):.3g~#P})."""
             )
         elif cue_times_sel.size > 1:
             n = cue_times_sel.size

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -263,7 +263,7 @@ def multiple_images_cli(args):
 
     print(
         f"Binning events into {num_images} images with an exposure time of "
-        f"{exposure_time:~.3g}."
+        f"{exposure_time:.3g~#P}."
     )
 
     with latrd_data(raw_files, keys=(event_location_key, event_time_key)) as data:
@@ -350,8 +350,8 @@ def pump_probe_cli(args):
 
         print(
             f"Binning events into {num_images} images with an exposure time of "
-            f"{exposure_time:~.3g} according to the time elapsed since the most recent "
-            f"'{cues[trigger_type]}' signal."
+            f"{exposure_time:.3g~#P} according to the time elapsed since the most "
+            f"recent '{cues[trigger_type]}' signal."
         )
 
         # Measure the event time as time elapsed since the most recent trigger signal.
@@ -427,9 +427,9 @@ def multiple_sequences_cli(args):
         print(
             f"Using '{cues[trigger_type]}' as the pump signal,\n"
             f"binning events into {num_intervals} sequences, corresponding to "
-            f"successive pump-probe delay intervals of {interval_time:~.3g}.\n"
+            f"successive pump-probe delay intervals of {interval_time:.3g~#P}.\n"
             f"Each sequence consists of {num_images} images with an effective exposure "
-            f"time of {exposure_time / num_intervals:~.3g}."
+            f"time of {exposure_time / num_intervals:.3g~#P}."
         )
 
         out_file_stem = out_file_pattern.stem


### PR DESCRIPTION
Sometimes, a Pint quantity gets rounded in an ugly way with the format specifier `~.3g`, like 999.999 ms becoming `1e+03 ms`.  Instead, use the the format specifier `.3g~#P`.  This isn't perfect (it gives `1 × 10³ ms` in this case, rather than `1 s`, because it compacts _before_ rounding) but it's considerably nicer.