### PR TITLE
Squash a dangling queue warning

### DIFF
--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -17,6 +17,7 @@ import zarr
 from dask import array as da
 from dask.diagnostics import ProgressBar
 from dask.distributed import Client, progress
+from distributed import wait
 from hdf5plugin import Bitshuffle
 from nexgen.nxs_copy import CopyTristanNexus
 
@@ -160,7 +161,7 @@ def save_multiple_images(
     # Use threads, rather than processes.
     with Client(processes=False):
         # Compute the array and store the values, using a progress bar.
-        print(progress(array.persist()) or "")
+        print(wait(progress(array.persist())) or "")
 
     print("Transferring the images to the output file.")
     store = zarr.DirectoryStore(intermediate)

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -161,7 +161,8 @@ def save_multiple_images(
     # Use threads, rather than processes.
     with Client(processes=False):
         # Compute the array and store the values, using a progress bar.
-        print(wait(progress(array.persist())) or "")
+        print(progress(array.persist()) or "")
+        wait(array)
 
     print("Transferring the images to the output file.")
     store = zarr.DirectoryStore(intermediate)

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -161,7 +161,8 @@ def save_multiple_images(
     # Use threads, rather than processes.
     with Client(processes=False):
         # Compute the array and store the values, using a progress bar.
-        print(progress(array.persist()) or "")
+        array = array.persist()
+        print(progress(array) or "")
         wait(array)
 
     print("Transferring the images to the output file.")


### PR DESCRIPTION
Don't try to close the Client context manager until the array store operation is done.  This removes a warning about a dangling queue.  When running `images multi`, instead of seeing this output:
```
Finding detector shutter open and close times.
[########################################] | 100% Completed | 13.1s
Binning events into 875 images with an exposure time of 200 ms.
[                                        ] | 0% Completed | 43.3s2022-05-13 14:46:40,638 - distributed.comm.inproc - WARNING - Closing dangling queue in <InProc  local=inproc://172.23.137.53/2715287/1 remote=inproc://172.23.137.53/2715287/9>
[########################################] | 100% Completed | 10min 22.6s
Transferring the images to the output file.
...
```
you see this output:
```
Finding detector shutter open and close times.
[########################################] | 100% Completed | 13.1s
Binning events into 875 images with an exposure time of 200 ms.
[########################################] | 100% Completed | 10min 22.6s
```