### PR TITLE
Refactor to better manage scheduler memory load

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ h5py==3.7.0
 hdf5plugin==3.3.1
 nexgen==0.6.13
 numpy==1.23.4
+pandas==1.5.1
 Pint==0.20.1
 zarr==2.13.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ h5py==3.7.0
 hdf5plugin==3.3.1
 nexgen==0.6.13
 numpy==1.23.4
+pandas==1.5.1
 Pint==0.20.1
 pytest==7.2.0
 pytest-cov==4.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     nexgen >= 0.6.8
     numpy
     pint
+    tqdm
     zarr
 packages = find:
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     hdf5plugin
     nexgen >= 0.6.8
     numpy
+    pandas
     pint
     zarr
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     nexgen >= 0.6.8
     numpy
     pint
-    tqdm
     zarr
 packages = find:
 package_dir =

--- a/src/tristan/__init__.py
+++ b/src/tristan/__init__.py
@@ -15,7 +15,6 @@ __version_tuple__ = tuple(int(x) for x in __version__.split("."))
 
 import dask
 import pint
-from dask import array as da
 from dask.distributed import progress, wait
 
 ureg = pint.UnitRegistry()
@@ -41,28 +40,3 @@ def compute_with_progress(collection):
     print(progress(futures) or "")
 
     wait(collection)
-
-
-def blockwise_selection(array: da.Array, selection: da.Array) -> da.Array:
-    """
-    Select from an array in a blockwise fashion, without computing chunk sizes.
-
-    Slicing a dask.Array with an array of bools or indices returns an array with
-    unknown chunk sizes, which causes problems for downstream Dask operations.  If
-    this is not a concern, (for example, if we are simply lumping the resulting array
-    into a bincount call, and have no need of the chunk size information),
-    we can save ourselves an expensive pass over the data by not computing the chunk
-    sizes at all.  This can be achieved by replacing Dask slicing with NumPy slicing,
-    mapped over all the blocks of an array.
-
-    Args:
-        array:      The array from which to take the selection.
-        selection:  An array of dtype bool, or an array of indices, specifying the
-                    desired selection from array.  There must be the same number of
-                    chunks as in array, and if the dtype is bool, the chunk sizes
-                    must match too.
-
-    Returns:
-        A slice from 'array', with the same dtype, and with the shape of 'selection'.
-    """
-    return da.map_blocks(lambda b, a: a[b], selection, array, dtype=array.dtype)

--- a/src/tristan/__init__.py
+++ b/src/tristan/__init__.py
@@ -13,12 +13,34 @@ __email__ = "dataanalysis@diamond.ac.uk"
 __version__ = "0.1.16"
 __version_tuple__ = tuple(int(x) for x in __version__.split("."))
 
+import dask
 import pint
 from dask import array as da
+from dask.distributed import progress, wait
 
 ureg = pint.UnitRegistry()
 
 clock_frequency = ureg.Quantity(6.4e8, "Hz").to_compact()
+
+
+def compute_with_progress(collection):
+    """
+    Compute a Dask collection, showing the progress of the top layer of the task graph.
+
+    Args:
+        collection:  A single Dask collection.
+    """
+    (collection,) = dask.persist(collection)
+
+    # View progress only of the top layer of the task graph, which consists
+    # of the rate limiting make_images tasks, to avoid giving a false sense
+    # of rapid progress from the quick execution of the large number of
+    # other, cheaper tasks.
+    *_, top_layer = collection.dask.layers.values()
+    futures = list(top_layer.values())
+    print(progress(futures) or "")
+
+    wait(collection)
 
 
 def blockwise_selection(array: da.Array, selection: da.Array) -> da.Array:

--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 from operator import mul
+from pathlib import Path
+from typing import Sequence
 
 import numpy as np
 import pandas as pd
+import zarr
 from dask import dataframe as dd
 from dask import distributed
 from numpy.typing import ArrayLike
@@ -14,8 +17,10 @@ from .data import (
     cue_time_key,
     event_location_key,
     event_time_key,
+    pixel_index,
     shutter_close,
     shutter_open,
+    valid_events,
 )
 
 
@@ -38,22 +43,98 @@ def find_start_end(data: dd.DataFrame) -> (int, int):
     return start, end
 
 
-def valid_events(data: dd.DataFrame, start: int, end: int) -> dd.DataFrame:
+def align_bins(start: int, align: int, end: int, n_bins: int) -> (int, int):
     """
-    Return those events that have a timestamp in the specified range.
+    Divide an interval into a specified number of bins, aligning with a given value.
+
+    Take three integers, ``start`` ≤ ``align`` ≤ ``end``, and find a way to span the
+    largest possible interval between ``start`` and ``end`` with a specified number of
+    bins, while ensuring that one of the bin edges is aligned with a specified value.
 
     Args:
-        data:   LATRD data, containing an 'event_time_offset' column and optional
-                'event_id' and 'event_energy' columns.
-        start:  The start time of the accepted range, in clock cycles.
-        end:    The end time of the accepted range, in clock cycles.
+        start:   The start of the interval.
+        align:   The value to which a bin edge should be aligned.
+        end:     The end of the interval.
+        n_bins:  The number of bins.
 
     Returns:
-        The valid events.
+        The first bin edge and the bin width, from which all the bin edges can be
+        derived.
     """
-    valid = (start <= data[event_time_key]) & (data[event_time_key] < end)
+    if align <= (start + end) / 2:
+        # Find the bin width by pinning a bin edge to the align time and the last bin
+        # edge to the end time, then maximising the number of bins we can fit between
+        # the start time and the trigger time.
+        # At least half the images must happen after the trigger time.
+        n_bins_after = np.arange(n_bins // 2 or 1, n_bins + 1)
+        bin_width = ((end - align) / n_bins_after).astype(int)
+        new_start = end - n_bins * bin_width
+        best = np.argmax(new_start >= start)
+        start = new_start[best]
+        bin_width = bin_width[best]
+    else:
+        # Find the bin width by pinning a bin edge to the align time and the first
+        # bin edge to the start time, then maximising the number of bins we can fit
+        # between the trigger time and the end time.
+        # At least half the images must happen before the trigger time.
+        n_bins_before = np.arange(n_bins // 2 or 1, n_bins + 1)
+        bin_width = ((align - start) / n_bins_before).astype(int)
+        new_end = start + n_bins * bin_width
+        best = np.argmax(new_end <= end)
+        bin_width = bin_width[best]
 
-    return data[valid]
+    return start, bin_width
+
+
+def create_cache(
+    output_file: Path | str, num_images: int, image_size: tuple[int, int]
+) -> zarr.Array:
+    """
+    Make a Zarr array of zeros, suitable for using as an image binning cache.
+
+    The array will have shape (num_images, *image_size) and will be chunked by image,
+    i.e. the chunk shape will be (1, *image_size).
+
+    Args:
+        output_file:  Output file name.  Any file extension will be replaces with .zarr.
+        num_images:   The number of images in the array.
+        image_size:   The size of an image in the array.
+
+    Returns:
+
+    """
+    shape = num_images, *image_size
+    chunks = 1, *image_size
+    output = Path(output_file).with_suffix(".zarr")
+    return zarr.zeros(
+        shape, chunks=chunks, dtype=np.int32, overwrite=True, store=output, path="data"
+    )
+
+
+def find_time_bins(data: pd.DataFrame, bins: Sequence[int]):
+    """
+    Convert the event timestamps in LATRD data to time bin indices.
+
+    For each event, determine the index of the bin into which the event will fall.
+
+    Args:
+        data:  LATRD events data.  Must have an ``event_time_offset`` column.
+        bins:  The time bin edges of the images (in clock cycles, to match the event
+               timestamps).
+
+    Returns:
+        A DataFrame which matches the input data except that the
+        ``event_time_offset`` column is replaced with a column of ``time_bin`` indices.
+    """
+    num_images = len(bins) - 1
+
+    # Find the index of the image to which each event belongs.
+    if num_images > 1:
+        data[event_time_key] = np.digitize(data[event_time_key], bins) - 1
+    elif num_images:
+        data[event_time_key] = 0
+
+    return data.rename(columns={event_time_key: "time_bin"})
 
 
 def make_images(data: pd.DataFrame, image_size: tuple[int, int], cache: ArrayLike):
@@ -66,8 +147,8 @@ def make_images(data: pd.DataFrame, image_size: tuple[int, int], cache: ArrayLik
     the full image stack.
 
     Args:
-        data:        LATRD data.  Must have one 'event_id' column and one
-                    'image_index' column.
+        data:        LATRD data.  Must have an ``event_id`` column and an
+                    ``image_index`` column.
         image_size:  The (y, x), i.e. (slow, fast) dimensions (number of pixels) of
                      the image.
         cache:       Array representing the image stack, to which the binned events
@@ -75,9 +156,9 @@ def make_images(data: pd.DataFrame, image_size: tuple[int, int], cache: ArrayLik
                      functions as an on-disk cache of the binned images.
     """
     # Construct a stack of images using dask.array.bincount and add them to the cache.
-    for image_index in data["image_index"].unique():
+    for image_index in data["time_bin"].unique():
         image_index = int(image_index)  # Convert to a serialisable type.
-        locations = data[event_location_key][data["image_index"] == image_index]
+        locations = data[event_location_key][data["time_bin"] == image_index]
         pixel_counts = np.bincount(locations, minlength=mul(*image_size))
         pixel_counts = pixel_counts.astype(np.uint32).reshape(image_size)
         with distributed.Lock(image_index):
@@ -92,24 +173,47 @@ def make_images(data: pd.DataFrame, image_size: tuple[int, int], cache: ArrayLik
     return pd.DataFrame(columns=data.columns)
 
 
-def find_image_indices(data: pd.DataFrame, bins: ArrayLike):
+def events_to_images(
+    data: dd.DataFrame,
+    bins: Sequence[int],
+    image_size: tuple[int, int],
+    cache: ArrayLike,
+) -> dd.DataFrame:
     """
-    FIXME
+    Construct a stack of images from events data.
+
+    From a sequence of LATRD events data, bin the events to images and store the
+    binned images in a cache array.  The cache may be backed with on-disk storage,
+    as in the case of a Zarr array, or may be a simple in-memory object, like a NumPy
+    array.
 
     Args:
-        data:  FIXME
-        bins:  The time bin edges of the images (in clock cycles, to match the event
-               timestamps).
+        data:        LATRD events data.  Must have an ``event_time_offset`` column
+                     and an ``event_id`` column.
+        bins:        The time bin edges of the images (in clock cycles, to match the
+                     event timestamps).
+        image_size:  The size of each image.
+        cache:       An array representing the eventual image stack, having shape
+                     ``(len(bins) - 1, *image_size)``, to which the pixel counts from
+                     this binning operation will be added.
 
     Returns:
-        FIXME
+        A Dask collection representing the lazy image binning computation.
     """
-    num_images = len(bins) - 1
+    # Consider only those events that occur between the start and end times.
+    data = valid_events(data, bins[0], bins[-1])
+    # Convert the event IDs to a form that is suitable for a NumPy bincount.
+    data[event_location_key] = pixel_index(data[event_location_key], image_size)
 
-    # Find the index of the image to which each event belongs.
-    if num_images > 1:
-        data[event_time_key] = np.digitize(data[event_time_key], bins) - 1
-    elif num_images:
-        data[event_time_key] = 0
+    columns = event_location_key, "time_bin"
+    dtypes = data.dtypes
+    dtypes["time_bin"] = dtypes.pop(event_time_key)
+    meta = pd.DataFrame(columns=columns).astype(dtype=dtypes)
+    data = data.map_partitions(find_time_bins, bins=bins, meta=meta)
 
-    return data.rename(columns={event_time_key: "image_index"})
+    # Bin to images, partition by partition.
+    data = dd.map_partitions(
+        make_images, data, image_size, cache, meta=meta, enforce_metadata=False
+    )
+
+    return data

--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from dask import array as da
 from dask import dataframe as dd
-from dask import delayed, distributed
+from dask import distributed
 from dask.diagnostics import ProgressBar
 from numpy.typing import ArrayLike
 
@@ -69,7 +69,6 @@ def valid_events(data: dd.DataFrame, start: int, end: int) -> dd.DataFrame:
     return data[valid]
 
 
-@delayed
 def make_images(
     data: pd.DataFrame, image_index: int, image_size: tuple[int, int], cache: ArrayLike
 ):
@@ -100,6 +99,8 @@ def make_images(
             image = image.astype(np.uint32).reshape(image_size)
             # Beware!  Using inplace addition (+=) here causes the locking to fail.
             cache[image_index] = cache[image_index] + image
+
+    return pd.DataFrame()
 
 
 def find_image_indices(data: pd.DataFrame, bins: ArrayLike):

--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -96,7 +96,7 @@ def create_cache(
     i.e. the chunk shape will be (1, *image_size).
 
     Args:
-        output_file:  Output file name.  Any file extension will be replaces with .zarr.
+        output_file:  Output file name.  Any file extension will be replaced with .zarr.
         num_images:   The number of images in the array.
         image_size:   The size of an image in the array.
 

--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -22,9 +22,7 @@ from .data import (
 )
 
 
-def find_start_end(
-    data: dict[str, da.Array], show_progress: bool = False
-) -> (int, int):
+def find_start_end(data: dd.DataFrame, show_progress: bool = False) -> (int, int):
     """
     Find the shutter open and shutter close timestamps.
 
@@ -43,12 +41,10 @@ def find_start_end(
     else:
         context = nullcontext
 
-    start_index = da.argmax(data[cue_id_key] == shutter_open)
-    end_index = da.argmax(data[cue_id_key] == shutter_close)
-    start, end = data[cue_time_key][[start_index, end_index]]
+    times = data[cue_time_key][data[cue_id_key].isin((shutter_open, shutter_close))]
 
     with context():
-        start, end = da.compute(start, end)
+        start, end = np.unique(da.compute(times))
 
     return start, end
 

--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -48,8 +48,7 @@ def find_start_end(data: dd.DataFrame, show_progress: bool = False) -> tuple[int
     else:
         start, end = da.compute(start, end)
 
-    start, end = data[cue_time_key].values[[start, end]]
-
+    start, end = data[cue_time_key].values.compute_chunk_sizes()[[start, end]]
     return da.compute(start, end)
 
 

--- a/src/tristan/binning.py
+++ b/src/tristan/binning.py
@@ -41,7 +41,8 @@ def find_start_end(data: dd.DataFrame, show_progress: bool = False) -> (int, int
     else:
         context = nullcontext
 
-    times = data[cue_time_key][data[cue_id_key].isin((shutter_open, shutter_close))]
+    indices = (data[cue_id_key] == shutter_open) | (data[cue_id_key] == shutter_close)
+    times = data[cue_time_key][indices]
 
     with context():
         start, end = np.unique(da.compute(times))

--- a/src/tristan/command_line/__init__.py
+++ b/src/tristan/command_line/__init__.py
@@ -161,7 +161,7 @@ def data_files(data_dir: Path, stem: str, n_dig: int = 6) -> (list[Path], Path):
     if not meta_file.exists():
         sys.exit(f"Could not find the expected detector metadata file:\n\t{meta_file}")
 
-    with h5py.File(meta_file, "r") as f:
+    with h5py.File(meta_file) as f:
         n_files = np.sum(f.get("fp_per_module", default=()))
 
     if n_files:

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -246,7 +246,7 @@ def multiple_images_cli(args):
     with latrd_data(raw_files, keys=(event_location_key, event_time_key)) as data:
         data = events_to_images(data, bins, image_size, images)
 
-        print("Calculating the binned images.")
+        print("Computing the binned images.")
         # Use multi-threading, rather than multi-processing.
         with Client(processes=False):
             compute_with_progress(data)
@@ -344,7 +344,7 @@ def pump_probe_cli(args):
         # Bin the events into images.
         events_data = events_to_images(events_data, bins, image_size, images)
 
-        print("Calculating the binned images.")
+        print("Computing the binned images.")
         # Use multi-threading, rather than multi-processing.
         with Client(processes=False):
             compute_with_progress(events_data)

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -275,6 +275,7 @@ def multiple_images_cli(args):
         chunks=(1, *image_size),
         overwrite=True,
         store=output_file.with_suffix(".zarr"),
+        synchronizer=zarr.ThreadSynchronizer(),
     )
 
     with latrd_data(raw_files, keys=(event_location_key, event_time_key)) as data:
@@ -285,14 +286,11 @@ def multiple_images_cli(args):
             bins,
             cache=images,
             meta=pd.DataFrame(),
-            enforce_metadata=False,
-            transform_divisions=False,
-            align_dataframes=False,
         ).to_delayed()
         # Use threads, rather than processes.
         with Client(processes=False):
             # Compute the array and store the values, using a progress bar.
-            print(progress(dask.compute(data)) or "")
+            print(progress(dask.persist(data)) or "")
 
     print("Transferring the images to the output file.")
     # with h5py.File(output_file, write_mode) as f:

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -295,17 +295,15 @@ def multiple_images_cli(args):
         # Convert the event IDs to a form that is suitable for a NumPy bincount.
         data[event_location_key] = pixel_index(data[event_location_key], image_size)
 
-        meta = pd.DataFrame(columns=data.columns).astype(dtype=data.dtypes)
+        columns = event_location_key, "image_index"
+        dtypes = data.dtypes
+        dtypes["image_index"] = dtypes.pop(event_time_key)
+        meta = pd.DataFrame(columns=columns).astype(dtype=dtypes)
         data = data.map_partitions(find_image_indices, bins=bins, meta=meta)
 
         # Bin to images, partition by partition.
         data = dd.map_partitions(
-            make_images,
-            data,
-            image_size,
-            images,
-            meta=pd.DataFrame(columns=data.columns),
-            enforce_metadata=False,
+            make_images, data, image_size, images, meta=meta, enforce_metadata=False
         )
 
         # Use threads, rather than processes.

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -16,12 +16,12 @@ import pandas as pd
 import pint
 import zarr
 from dask import array as da
+from dask import dataframe as dd
 from dask.diagnostics import ProgressBar
 from dask.distributed import Client, diagnostics, progress, wait
 from hdf5plugin import Bitshuffle
 from nexgen.nxs_copy import CopyTristanNexus
 from tqdm import tqdm
-from tqdm.contrib.itertools import product
 
 from .. import blockwise_selection, clock_frequency
 from ..binning import find_image_indices, find_start_end, make_images, valid_events
@@ -63,12 +63,12 @@ class TqdmLikeDask(tqdm):
         d["elapsed_str"] = self.format_interval(d.get("elapsed", 0))
         return d
 
-    def __init__(self, **kwargs):
+    def __init__(self, iterable=None, **kwargs):
         dask_params = {
             "ascii": " #",
             "bar_format": "[{bar:40}] | {percentage:.0f}% Completed | {elapsed_str}",
         }
-        super(TqdmLikeDask, self).__init__(**dask_params, **kwargs)
+        super(TqdmLikeDask, self).__init__(iterable=iterable, **dask_params, **kwargs)
 
 
 def determine_image_size(nexus_file: Path) -> tuple[int, int]:
@@ -316,15 +316,20 @@ def multiple_images_cli(args):
         # Use threads, rather than processes.
         with Client(processes=False):
             # Bin to images, partition by partition.
-            bincounts = []
             print("Assembling the list of binning tasks.")
-            for df, i in product(
-                data.partitions,
-                range(num_images),
-                tqdm_class=TqdmLikeDask,
-                total=num_images * data.npartitions,
-            ):
-                bincounts.append(make_images(df, i, image_size, images))
+            bincounts = []
+            for i in TqdmLikeDask(range(num_images)):
+                bincounts.append(
+                    dd.map_partitions(
+                        make_images,
+                        data,
+                        i,
+                        image_size,
+                        images,
+                        meta=pd.DataFrame(),
+                        enforce_metadata=False,
+                    )
+                )
 
             # Compute the array and store the values, using a progress bar.
             print("Calculating the binned images.")

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -113,8 +113,9 @@ def single_image_cli(args):
 
     raw_files, _ = data_files(args.data_dir, args.stem)
 
-    with latrd_data(raw_files, keys=cue_keys, dataframe=False) as data:
-        start, end = find_start_end(data, show_progress=True)
+    print("Finding detector shutter open and close times.")
+    with latrd_data(raw_files, keys=cue_keys) as data, ProgressBar():
+        start, end = find_start_end(data)
 
     print("Binning events into a single image.")
     with latrd_data(raw_files, keys=(event_location_key, event_time_key)) as data:
@@ -246,9 +247,10 @@ def multiple_images_cli(args):
 
     raw_files, _ = data_files(args.data_dir, args.stem)
 
-    print("Finding detector shutter open and close times.")
-    with latrd_data(raw_files, keys=cue_keys, dataframe=False) as data, ProgressBar():
-        start, end = dask.compute(find_start_end(data))
+    with latrd_data(raw_files, keys=cue_keys) as data:
+        print("Finding detector shutter open and close times.")
+        with ProgressBar():
+            start, end = find_start_end(data)
         exposure_time, exposure_cycles, num_images = exposure(
             start, end, args.exposure_time, args.num_images
         )

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -19,10 +19,9 @@ import zarr
 from dask import array as da
 from dask import dataframe as dd
 from dask.diagnostics import ProgressBar
-from dask.distributed import Client, diagnostics, progress, wait
+from dask.distributed import Client, progress, wait
 from hdf5plugin import Bitshuffle
 from nexgen.nxs_copy import CopyTristanNexus
-from tqdm import tqdm
 
 from .. import blockwise_selection, clock_frequency
 from ..binning import find_image_indices, find_start_end, make_images, valid_events
@@ -49,27 +48,6 @@ from . import (
     triggers,
     version_parser,
 )
-
-
-class TqdmLikeDask(tqdm):
-    """A tqdm progress bar with a format that mimics Dask Distributed's 'progress'."""
-
-    @staticmethod
-    def format_interval(t):
-        return diagnostics.progress.format_time(t)
-
-    @property
-    def format_dict(self):
-        d = super(TqdmLikeDask, self).format_dict
-        d["elapsed_str"] = self.format_interval(d.get("elapsed", 0))
-        return d
-
-    def __init__(self, iterable=None, **kwargs):
-        dask_params = {
-            "ascii": " #",
-            "bar_format": "[{bar:40}] | {percentage:.0f}% Completed | {elapsed_str}",
-        }
-        super(TqdmLikeDask, self).__init__(iterable=iterable, **dask_params, **kwargs)
 
 
 def determine_image_size(nexus_file: Path) -> tuple[int, int]:

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -78,7 +78,7 @@ def determine_image_size(nexus_file: Path) -> tuple[int, int]:
     try:
         with h5py.File(nexus_file) as f:
             # For the sake of some functions like zarr.create, ensure that the image
-            # dimensions are definintely tuple[int, int], not tuple[np.int64,
+            # dimensions are definitely tuple[int, int], not tuple[np.int64,
             # np.int64] or anything else.
             y, x = map(int, f["entry/instrument/detector/module/data_size"][()])
             return y, x

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -336,8 +336,8 @@ def multiple_images_cli(args):
             make_images, data, image_size, images, meta=meta, enforce_metadata=False
         )
 
-        # Use threads, rather than processes.
-        with Client(processes=False):
+        # Use multiprocessing.
+        with Client():
             # Compute the array and store the values, using a progress bar.
             print("Calculating the binned images.")
             (data,) = dask.persist(data)

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -73,6 +73,22 @@ def determine_image_size(nexus_file: Path) -> tuple[int, int]:
 def exposure(
     start: int, end: int, exposure_time: pint.Quantity = None, num_images: int = None
 ) -> (pint.Quantity, int, int):
+    """
+    Find the exposure time or number of images.
+
+    From a start time and an end time, either derive an exposure time from the
+    number of images, or derive the number of images from the exposure time.
+
+    Args:
+        start:          Start time in clock cycles.
+        end:            End time in clock cycles.
+        exposure_time:  Exposure time in any unit of time (optional).
+        num_images:     Number of images (optional).
+
+    Returns:
+        The exposure time in seconds, the exposure time in clock cycles, the number
+        of images.
+    """
     if exposure_time:
         exposure_time = exposure_time.to_base_units().to_compact()
         exposure_cycles = (exposure_time * clock_frequency).to_base_units().magnitude

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -333,13 +333,9 @@ def multiple_images_cli(args):
 
             # Compute the array and store the values, using a progress bar.
             print("Calculating the binned images.")
-            if num_images < 1000:
-                bincounts = dask.persist(bincounts)
-                print(progress(bincounts) or "")
-                wait(bincounts)
-            else:
-                for bincount in TqdmLikeDask(bincounts):
-                    bincount.compute()
+            bincounts = dask.persist(bincounts, optimize_graph=False)
+            print(progress(bincounts) or "")
+            wait(bincounts)
 
     print("Transferring the images to the output file.")
     with h5py.File(output_file, write_mode) as f:

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -312,6 +312,10 @@ def pump_probe_cli(args):
 
         if not trigger_times.size:
             sys.exit(f"Could not find a '{cues[trigger_type]}' signal.")
+        elif not trigger_times.size > 1:
+            sys.exit(
+                f"Only one '{cues[trigger_type]}' signal found.  Two or more needed."
+            )
 
         end = da.diff(trigger_times).min()
         exposure_time, num_images = args.exposure_time, args.num_images

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -113,8 +113,7 @@ def single_image_cli(args):
 
     raw_files, _ = data_files(args.data_dir, args.stem)
 
-    print("Finding detector shutter open and close times.")
-    with latrd_data(raw_files, keys=cue_keys, dataframe=False) as data:
+    with latrd_data(raw_files, keys=cue_keys) as data:
         start, end = find_start_end(data, show_progress=True)
 
     print("Binning events into a single image.")

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -17,7 +17,7 @@ import pint
 import zarr
 from dask import array as da
 from dask.diagnostics import ProgressBar
-from dask.distributed import Client, diagnostics, progress
+from dask.distributed import Client, diagnostics, progress, wait
 from hdf5plugin import Bitshuffle
 from nexgen.nxs_copy import CopyTristanNexus
 from tqdm import tqdm
@@ -328,7 +328,9 @@ def multiple_images_cli(args):
 
             # Compute the array and store the values, using a progress bar.
             print("Calculating the binned images.")
-            print(progress(dask.persist(bincounts)) or "")
+            bincounts = dask.persist(bincounts)
+            print(progress(bincounts) or "")
+            wait(bincounts)
 
     print("Transferring the images to the output file.")
     with h5py.File(output_file, write_mode) as f:

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -113,7 +113,7 @@ def single_image_cli(args):
 
     raw_files, _ = data_files(args.data_dir, args.stem)
 
-    with latrd_data(raw_files, keys=cue_keys) as data:
+    with latrd_data(raw_files, keys=cue_keys, dataframe=False) as data:
         start, end = find_start_end(data, show_progress=True)
 
     print("Binning events into a single image.")

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -333,9 +333,13 @@ def multiple_images_cli(args):
 
             # Compute the array and store the values, using a progress bar.
             print("Calculating the binned images.")
-            bincounts = dask.persist(bincounts, optimize_graph=False)
-            print(progress(bincounts) or "")
-            wait(bincounts)
+            if num_images < 1000:
+                bincounts = dask.persist(bincounts)
+                print(progress(bincounts) or "")
+                wait(bincounts)
+            else:
+                for bincount in TqdmLikeDask(bincounts):
+                    bincount.compute()
 
     print("Transferring the images to the output file.")
     with h5py.File(output_file, write_mode) as f:

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -64,7 +64,7 @@ def determine_image_size(nexus_file: Path) -> tuple[int, int]:
             # For the sake of some functions like zarr.create, ensure that the image
             # dimensions are definitely tuple[int, int], not tuple[np.int64,
             # np.int64] or anything else.
-            y, x = map(int, f["entry/instrument/detector/module/data_size"][()])
+            y, x = f["entry/instrument/detector/module/data_size"][()].astype(int)
             return y, x
     except (FileNotFoundError, OSError):
         sys.exit(f"Cannot find NeXus file:\n\t{nexus_file}\n{recommend}")

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -328,7 +328,7 @@ def multiple_images_cli(args):
 
             # Compute the array and store the values, using a progress bar.
             print("Calculating the binned images.")
-            bincounts = dask.persist(bincounts)
+            bincounts = dask.persist(bincounts, optimize_graph=False)
             print(progress(bincounts) or "")
             wait(bincounts)
 

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -114,8 +114,8 @@ def single_image_cli(args):
     raw_files, _ = data_files(args.data_dir, args.stem)
 
     print("Finding detector shutter open and close times.")
-    with latrd_data(raw_files, keys=cue_keys, dataframe=False) as data, ProgressBar():
-        start, end = dask.compute(find_start_end(data))
+    with latrd_data(raw_files, keys=cue_keys, dataframe=False) as data:
+        start, end = find_start_end(data, show_progress=True)
 
     print("Binning events into a single image.")
     with latrd_data(raw_files, keys=(event_location_key, event_time_key)) as data:

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -113,8 +113,9 @@ def single_image_cli(args):
 
     raw_files, _ = data_files(args.data_dir, args.stem)
 
-    with latrd_data(raw_files, keys=cue_keys) as data:
-        start, end = find_start_end(data, show_progress=True)
+    print("Finding detector shutter open and close times.")
+    with latrd_data(raw_files, keys=cue_keys, dataframe=False) as data, ProgressBar():
+        start, end = dask.compute(find_start_end(data))
 
     print("Binning events into a single image.")
     with latrd_data(raw_files, keys=(event_location_key, event_time_key)) as data:
@@ -246,8 +247,9 @@ def multiple_images_cli(args):
 
     raw_files, _ = data_files(args.data_dir, args.stem)
 
-    with latrd_data(raw_files, keys=cue_keys) as data:
-        start, end = find_start_end(data)
+    print("Finding detector shutter open and close times.")
+    with latrd_data(raw_files, keys=cue_keys, dataframe=False) as data, ProgressBar():
+        start, end = dask.compute(find_start_end(data))
         exposure_time, exposure_cycles, num_images = exposure(
             start, end, args.exposure_time, args.num_images
         )

--- a/src/tristan/command_line/vds.py
+++ b/src/tristan/command_line/vds.py
@@ -40,7 +40,7 @@ def main(args=None):
     output_file = check_output_file(args.output_file, suffix="vds", force=args.force)
 
     raw_files, meta_file = data_files(args.data_dir, args.stem)
-    with h5py.File(meta_file, "r") as f:
+    with h5py.File(meta_file) as f:
         ts_info = time_slice_info(f)
         layouts = virtual_data_set(raw_files, f, *ts_info)
 

--- a/src/tristan/data.py
+++ b/src/tristan/data.py
@@ -187,6 +187,24 @@ def seconds(timestamp: int, reference: int = 0) -> Quantity:
     return ((timestamp - reference) / clock_frequency).to_base_units().to_compact()
 
 
+def valid_events(data: dd.DataFrame, start: int, end: int) -> dd.DataFrame:
+    """
+    Return those events that have a timestamp in the specified range.
+
+    Args:
+        data:   LATRD data, containing an 'event_time_offset' column and optional
+                'event_id' and 'event_energy' columns.
+        start:  The start time of the accepted range, in clock cycles.
+        end:    The end time of the accepted range, in clock cycles.
+
+    Returns:
+        The valid events.
+    """
+    valid = (start <= data[event_time_key]) & (data[event_time_key] < end)
+
+    return data[valid]
+
+
 def pixel_index(location: ArrayLike, image_size: tuple[int, int]) -> ArrayLike:
     """
     Extract pixel coordinate information from an event location (event_id) message.

--- a/src/tristan/data.py
+++ b/src/tristan/data.py
@@ -145,7 +145,9 @@ def latrd_data(
         ]
 
         data = {
-            k: aggregate_chunks(da.concatenate([da.from_array(f[k]) for f in files]))
+            k: aggregate_chunks(
+                da.concatenate([da.from_array(f[k], inline_array=True) for f in files])
+            )
             for k in keys
         }
 

--- a/src/tristan/data.py
+++ b/src/tristan/data.py
@@ -191,8 +191,8 @@ def pixel_index(location: ArrayLike, image_size: tuple[int, int]) -> ArrayLike:
     flattened image array by multiplying the y value by the size of the array in x,
     and adding the x value.
 
-    This function calls the Python built-in divmod and so can be broadcast over NumPy
-    and Dask arrays.
+    This function calls the Python built-in divmod and so can be broadcast over
+    array-like data structures.
 
     Args:
         location:    Event location message (an integer).

--- a/src/tristan/data.py
+++ b/src/tristan/data.py
@@ -83,7 +83,6 @@ nx_size_key = "entry/instrument/detector/module/data_size"
 def latrd_data(
     raw_file_paths: Iterable[str | Path],
     keys: Iterable[str] = cue_keys + event_keys,
-    dataframe=True,
 ) -> dd.DataFrame | dict[str, da.Array]:
     """
     A context manager to read LATRD data sets from multiple files.
@@ -94,15 +93,9 @@ def latrd_data(
     the default Dask array chunk size, but with chunk boundaries aligned with HDF5
     file boundaries.
 
-    This can either yield a Dask DataFrame or a dictionary of Dask arrays.  The former
-    can make certain slicing operations simpler.  The latter can be useful because
-    Dask DataFrames discard the known chunk/partition sizes but some computations can
-    be made simpler if redundant compute_chunk_sizes calls can be avoided.
-
     Args:
         raw_file_paths:  The paths of the raw LATRD data files.
         keys:  The set of LATRD data keys to be read.
-        dataframe:  Yield a Dask DataFrame if True, or else a dictionary of Dask arrays.
 
     Yields:
         The data from all the files.
@@ -121,11 +114,9 @@ def latrd_data(
             k: da.concatenate([da.from_array(f[k], chunks=block_length) for f in files])
             for k in keys
         }
-
-        if dataframe:
-            data = dd.concat(
-                [dd.from_dask_array(v, columns=k) for k, v in data.items()], axis=1
-            )
+        data = dd.concat(
+            [dd.from_dask_array(v, columns=k) for k, v in data.items()], axis=1
+        )
 
         yield data
 

--- a/src/tristan/data.py
+++ b/src/tristan/data.py
@@ -81,8 +81,10 @@ nx_size_key = "entry/instrument/detector/module/data_size"
 
 @contextmanager
 def latrd_data(
-    raw_file_paths: Iterable[str | Path], keys: Iterable[str] = cue_keys + event_keys
-) -> dd.DataFrame:
+    raw_file_paths: Iterable[str | Path],
+    keys: Iterable[str] = cue_keys + event_keys,
+    dataframe=True,
+) -> dd.DataFrame | dict[str, da.Array]:
     """
     A context manager to read LATRD data sets from multiple files.
 
@@ -92,12 +94,18 @@ def latrd_data(
     the default Dask array chunk size, but with chunk boundaries aligned with HDF5
     file boundaries.
 
+    This can either yield a Dask DataFrame or a dictionary of Dask arrays.  The former
+    can make certain slicing operations simpler.  The latter can be useful because
+    Dask DataFrames discard the known chunk/partition sizes but some computations can
+    be made simpler if redundant compute_chunk_sizes calls can be avoided.
+
     Args:
         raw_file_paths:  The paths of the raw LATRD data files.
         keys:  The set of LATRD data keys to be read.
+        dataframe:  Yield a Dask DataFrame if True, or else a dictionary of Dask arrays.
 
     Yields:
-        The data from all the files, incorporated into a single DataFrame.
+        The data from all the files.
     """
     with ExitStack() as stack:
         files = [stack.enter_context(h5py.File(p, swmr=True)) for p in raw_file_paths]
@@ -113,9 +121,10 @@ def latrd_data(
             k: da.concatenate([da.from_array(f[k], chunks=block_length) for f in files])
             for k in keys
         }
-        data = dd.concat(
-            [dd.from_dask_array(v, columns=k) for k, v in data.items()], axis=1
-        )
+        if dataframe:
+            data = dd.concat(
+                [dd.from_dask_array(v, columns=k) for k, v in data.items()], axis=1
+            )
         yield data
 
 

--- a/src/tristan/data.py
+++ b/src/tristan/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from contextlib import ExitStack, contextmanager
+from functools import partial
 from pathlib import Path
 from typing import Iterable
 
@@ -14,6 +15,7 @@ from dask import array as da
 from dask import dataframe as dd
 from numpy.typing import ArrayLike
 from pint import Quantity
+from toolz import valmap
 
 from . import clock_frequency, ureg
 
@@ -79,6 +81,35 @@ event_keys = event_location_key, event_time_key, event_energy_key
 nx_size_key = "entry/instrument/detector/module/data_size"
 
 
+def aggregate_chunks(array: da.Array, target_size: int) -> da.Array:
+    """
+    Concatenate adjacent small chunks in a one-dimensional Dask array.
+
+    Reduce the total number of chunks in a one-dimensional Dask array by joining
+    adjacent chunks that are smaller than the optimal chunk size, as determined by
+    the Dask config 'array.chunk-size'.
+
+    Args:
+        array:        A one-dimensional Dask array.
+        target_size:  The optimal number of data per Dask chunk.
+
+    Returns:
+        The input array, rechunked to minimise the number of chunks.
+    """
+    new_chunks = []
+    (old_chunks,) = array.chunks
+    for chunk in old_chunks:
+        if new_chunks and new_chunks[-1] + chunk <= target_size:
+            # If this input data set will fit into the current Dask chunk, add it.
+            new_chunks[-1] += chunk
+        else:
+            # If the current chunk is full (or the chunks list is empty), add this
+            # data set to the next chunk.
+            new_chunks.append(chunk)
+
+    return array.rechunk(new_chunks)
+
+
 @contextmanager
 def latrd_data(
     raw_file_paths: Iterable[str | Path],
@@ -121,10 +152,14 @@ def latrd_data(
             k: da.concatenate([da.from_array(f[k], chunks=block_length) for f in files])
             for k in keys
         }
+        aggregate = partial(aggregate_chunks, target_size=block_length)
+        data = valmap(aggregate, data)
+
         if dataframe:
             data = dd.concat(
                 [dd.from_dask_array(v, columns=k) for k, v in data.items()], axis=1
             )
+
         yield data
 
 

--- a/src/tristan/vds.py
+++ b/src/tristan/vds.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Tools for creating and manipulating an HDF5 VDS for Tristan data."""
+
+from __future__ import annotations
 
 from contextlib import ExitStack
 from itertools import chain, compress, cycle, zip_longest


### PR DESCRIPTION
This is a fairly substantial refactor and this branch has a lot of history, so its commits don't make all that much sense as a narrative.

The short story is that the existing logic of iterating over the images to which events must be written, and searching each chunk of events data for events to add to that image, does not allow the scheduler to dispose of intermediate results easily, since every task in the image binning layers has dependencies on every task in the previous layers.

In this new logic, a single Zarr array is used as a cache and image binning is performed by iterating chunkwise over the events data, creating a partial image from the events in each chunk and adding it to the cache.  This removes the need for the scheduler to hold intermediate results in memory and better parallelises the task graph.

The benefit is most pronounced when binning large numbers of events into large numbers of images, where previously the scheduler would sometimes require more memory than availble, to store the overwhelming volume of intermediate results data.

Closes #66.