### PR TITLE
TTL improvements

### DIFF
--- a/src/tristan/diagnostics/find_trigger_intervals.py
+++ b/src/tristan/diagnostics/find_trigger_intervals.py
@@ -111,9 +111,9 @@ def trigger_lookup(tristanlist):
         f"Module {mod_number}": {
             "Shutter open": sh_open,
             "Shutter close": sh_close,
-            "LVDS re": lvds_re,
-            "LVDS fe": lvds_fe,
-            "TTL re": ttl_re,
+            "LVDS re": sorted(lvds_re),
+            "LVDS fe": sorted(lvds_fe),
+            "TTL re": sorted(ttl_re),
         }
     }
     return D
@@ -169,11 +169,11 @@ def trigger_lookup_ssx(tristanlist):
         f"Module {mod_number}": {
             "Shutter open": sh_open,
             "Shutter close": sh_close,
-            "LVDS re": lvds_re,
-            "LVDS fe": lvds_fe,
-            "TTL re": ttl_re,
-            "SYNC re": sync_re,
-            "SYNC fe": sync_fe,
+            "LVDS re": sorted(lvds_re),
+            "LVDS fe": sorted(lvds_fe),
+            "TTL re": sorted(ttl_re),
+            "SYNC re": sorted(sync_re),
+            "SYNC fe": sorted(sync_fe),
         }
     }
     return D
@@ -315,7 +315,7 @@ def main(args):
                 elif len(v["SYNC re"]) == 0:
                     logger.warning("No SYNC rising edges found!")
                 elif len(v["SYNC fe"]) == 0:
-                    logger.warning("No SYNC rising edges found!")
+                    logger.warning("No SYNC falling edges found!")
         logger.info("\n")
 
 

--- a/src/tristan/diagnostics/find_trigger_intervals.py
+++ b/src/tristan/diagnostics/find_trigger_intervals.py
@@ -283,17 +283,35 @@ def main(args):
                     logger.info(
                         f"Time difference between first TTL and LVDS re: {diff2:.4f} s."
                     )
-                    n_before = np.where(v["TTL re"] < v["LVDS re"][0])[0]
-                    if len(n_before) > 0:
+                    before = np.where(v["TTL re"] < v["LVDS re"][0])[0]
+                    if len(before) > 0:
                         logger.info(
-                            f"{len(n_before)} TTL triggers found before LVDS rising edge."
+                            f"{len(before)} TTL triggers found before LVDS rising edge."
                         )
-                        print(len(v["TTL re"][n_before]))
+                        new_re = [
+                            el for n, el in enumerate(v["TTL re"]) if n not in before
+                        ]
+                        diff2_1 = new_re[0] - v["LVDS re"][0]
+                        logger.info(
+                            f"Time difference between LVDS re and first TTL after it: {diff2_1}"
+                        )
                 if len(v["LVDS fe"]) > 0:
                     diff3 = v["LVDS fe"][0] - v["TTL re"][-1]
                     logger.info(
                         f"Time difference between LVDS fe and last TTL: {diff3:.4f} s."
                     )
+                    after = np.where(v["TTL re"] > v["LVDS fe"][0])[0]
+                    if len(after) > 0:
+                        logger.info(
+                            f"{len(after)} TTL triggers found before LVDS falling edge."
+                        )
+                        new_re = [
+                            el for n, el in enumerate(v["TTL re"]) if n not in after
+                        ]
+                        diff3_1 = v["LVDS fe"][0] - new_re[-1]
+                        logger.info(
+                            f"Time difference between LVDS re and last TTL after it: {diff3_1}"
+                        )
             else:
                 logger.warning("No TTL triggers found!")
             # If SSX, print out SYNC info.

--- a/src/tristan/diagnostics/find_trigger_intervals.py
+++ b/src/tristan/diagnostics/find_trigger_intervals.py
@@ -279,12 +279,16 @@ def main(args):
                     f"Average time interval between one TTL re and the next: {d_avg:.4} s"
                 )
                 if len(v["LVDS re"]) > 0:
-                    n = np.where(v["TTL re"] < v["LVDS re"][0])[0]
-                    logger.info(f"Number of TTL triggers before LVDS re: {len(n)}")
                     diff2 = v["TTL re"][0] - v["LVDS re"][0]
                     logger.info(
                         f"Time difference between first TTL and LVDS re: {diff2:.4f} s."
                     )
+                    n_before = np.where(v["TTL re"] < v["LVDS re"][0])[0]
+                    if len(n_before) > 0:
+                        logger.info(
+                            f"{len(n_before)} TTL triggers found before LVDS rising edge."
+                        )
+                        print(len(v["TTL re"][n_before]))
                 if len(v["LVDS fe"]) > 0:
                     diff3 = v["LVDS fe"][0] - v["TTL re"][-1]
                     logger.info(

--- a/src/tristan/diagnostics/find_trigger_intervals.py
+++ b/src/tristan/diagnostics/find_trigger_intervals.py
@@ -279,6 +279,8 @@ def main(args):
                     f"Average time interval between one TTL re and the next: {d_avg:.4} s"
                 )
                 if len(v["LVDS re"]) > 0:
+                    n = np.where(v["TTL re"] < v["LVDS re"][0])[0]
+                    logger.info(f"Number of TTL triggers before LVDS re: {len(n)}")
                     diff2 = v["TTL re"][0] - v["LVDS re"][0]
                     logger.info(
                         f"Time difference between first TTL and LVDS re: {diff2:.4f} s."

--- a/src/tristan/diagnostics/find_trigger_intervals.py
+++ b/src/tristan/diagnostics/find_trigger_intervals.py
@@ -293,7 +293,7 @@ def main(args):
                         ]
                         diff2_1 = new_re[0] - v["LVDS re"][0]
                         logger.info(
-                            f"Time difference between LVDS re and first TTL after it: {diff2_1}"
+                            f"Time difference between LVDS re and first TTL after it: {diff2_1:.4f} s."
                         )
                 if len(v["LVDS fe"]) > 0:
                     diff3 = v["LVDS fe"][0] - v["TTL re"][-1]
@@ -310,7 +310,7 @@ def main(args):
                         ]
                         diff3_1 = v["LVDS fe"][0] - new_re[-1]
                         logger.info(
-                            f"Time difference between LVDS re and last TTL after it: {diff3_1}"
+                            f"Time difference between LVDS re and last TTL after it: {diff3_1:.4f} s."
                         )
             else:
                 logger.warning("No TTL triggers found!")


### PR DESCRIPTION
Do not assume that all triggers are in order.
Check how many TTLs (if any) fall before and after LVDS up and down. 
Print correct time difference.