### PR TITLE
Sequences persist workaround

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     dask[array,diagnostics,distributed] != 2021.3.*
     h5py>=3.8
     hdf5plugin>=4.0.1
-    nexgen >= 0.6.20
+    nexgen >= 0.7.2
     numpy
     pandas
     pint
@@ -45,7 +45,7 @@ python_requires = >=3.8
 zip_safe = False
 
 [options.extras_require]
-dev = 
+dev =
     black
     pytest-cov
     pytest-random-order

--- a/src/tristan/__init__.py
+++ b/src/tristan/__init__.py
@@ -22,21 +22,30 @@ ureg = pint.UnitRegistry()
 clock_frequency = ureg.Quantity(6.4e8, "Hz").to_compact()
 
 
-def compute_with_progress(collection):
+def compute_with_progress(collection, do_not_persist=False):
     """
     Compute a Dask collection, showing the progress of the top layer of the task graph.
 
     Args:
         collection:  A single Dask collection.
     """
-    (collection,) = dask.persist(collection)
-
-    # View progress only of the top layer of the task graph, which consists
-    # of the rate limiting make_images tasks, to avoid giving a false sense
-    # of rapid progress from the quick execution of the large number of
-    # other, cheaper tasks.
-    *_, top_layer = collection.dask.layers.values()
-    futures = list(top_layer.values())
-    print(progress(futures) or "")
+    if do_not_persist is False:
+        (collection,) = dask.persist(collection)
+        # View progress only of the top layer of the task graph, which consists
+        # of the rate limiting make_images tasks, to avoid giving a false sense
+        # of rapid progress from the quick execution of the large number of
+        # other, cheaper tasks.
+        *_, top_layer = collection.dask.layers.values()
+        futures = list(top_layer.values())
+        print(progress(futures) or "")
+    else:
+        print("Binning in progress.")
+        print(
+            """
+            Warning!
+            Progress bar disabled but binning still going on in the background.
+            Please wait ...
+            """
+        )
 
     wait(collection)

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -502,7 +502,7 @@ def multiple_sequences_cli(args):
         print("Computing the binned images.")
         # Use multi-threading, rather than multi-processing.
         with Client(processes=False):
-            compute_with_progress(events_data)
+            compute_with_progress(events_data, do_not_persist=True)
 
     print("Transferring the images to the output files.")
     store = images.store
@@ -671,7 +671,7 @@ def gated_images_cli(args):
         print("Computing the binned images.")
         # Use multi-threading, rather than multi-processing.
         with Client(processes=False):
-            compute_with_progress(data)
+            compute_with_progress(data, do_not_persist=True)
 
     print("Transferring the images to the output file.")
     with h5py.File(output_file, write_mode) as f:


### PR DESCRIPTION
Workaround that disables the binning progress bar to avoid using persist on open hdf5 files, which cannot be pickled. 

Also, update some dependencies.

