### PR TITLE
Avoid problem serialising h5py objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools<57", "wheel==0.33.1"]
-build-backend = "setuptools.build_meta"
-
 [tool.isort]
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,10 +30,10 @@ project-urls =
 [options]
 include_package_data = True
 install_requires =
-    dask[array,diagnostics,distributed] != 2021.3.*
+    dask[array,diagnostics,distributed]!=2021.3.*,<2023.4
     h5py>=3.8
     hdf5plugin>=4.0.1
-    nexgen >= 0.7.2
+    nexgen>=0.7.2
     numpy
     pandas
     pint


### PR DESCRIPTION
Limit the version of dependency Dask Distributed to avoid problems with serialising h5py objects in Dask task graphs with the distributed scheduler.  This issue arises due to changes introduced
in [version 2023.4.0](https://distributed.dask.org/en/stable/changelog.html#v2023-4-0) of Dask Distributed.

See dask/distributed#7564 for details.

Fixes #104.