### PR TITLE
Make trigger diagnostics work for dark field data

### DIFF
--- a/src/tristan/diagnostics/find_trigger_intervals.py
+++ b/src/tristan/diagnostics/find_trigger_intervals.py
@@ -395,9 +395,8 @@ def main(args):
     else:
         nproc = mp.cpu_count() - 1
 
-    L, _ = assign_files_to_modules(file_list, args.num_modules)
+    L, _ = assign_files_to_modules(file_list, args.num_modules, "cues")
     tristanlist = [l + (args.expt,) for l in list(L.items())]  # noqa: E741
-    # tristanlist = list(L.items())
 
     logger.info(f"Start Pool with {nproc} processes.")
     with mp.Pool(processes=nproc) as pool:

--- a/src/tristan/diagnostics/find_trigger_intervals.py
+++ b/src/tristan/diagnostics/find_trigger_intervals.py
@@ -88,6 +88,9 @@ parser.add_argument(
     type=str,
     help="Number of detector modules.",
 )
+parser.add_argument(
+    "-nxs", "--nexus", type=str, help="Nexus filename if different from filename.nxs."
+)
 
 
 # Define a logger object
@@ -384,11 +387,15 @@ def main(args):
         f"Look for triggers in cue messages for a Tristan{args.num_modules} {args.expt} collection."
     )
 
-    nxsfile = filepath / (args.filename + ".nxs")
+    nxsfile = (
+        filepath / (args.filename + ".nxs") if not args.nexus else filepath / args.nexus
+    )
     if nxsfile in filepath.iterdir():
         with h5py.File(nxsfile) as nxs:
             count_time = nxs["/entry/instrument/detector/count_time"][()]
-        logger.info(f"Total collection time recorded in NeXus file: {count_time} s.\n")
+        logger.info(
+            f"Total collection time recorded in NeXus file ({nxsfile.name}): {count_time} s.\n"
+        )
 
     if args.nproc:
         nproc = args.nproc

--- a/src/tristan/diagnostics/utils.py
+++ b/src/tristan/diagnostics/utils.py
@@ -5,7 +5,6 @@ import glob
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import Literal, get_args
 
 import h5py
 import numpy as np
@@ -31,12 +30,22 @@ class FileChecker(str, Enum):
     EVENTS = "events"
 
 
+class TristanConfig(str, Enum):
+    T1M = "1M"
+    T2M = "2M"
+    T10M = "10M"
+
+    @staticmethod
+    def config_opts():
+        return list(map(lambda d: d.value, TristanConfig))
+
+
+TRISTAN_CONFIG = {"10M": (2, 5), "2M": (1, 2), "1M": (1, 1)}  # (H, V) -.> (fast, slow)
+
 # Tristan 10M specs
-TConfig = Literal["1M", "2M", "10M"]
-tristan_config = {"10M": (2, 5), "2M": (1, 2), "1M": (1, 1)}  # (H, V) -.> (fast, slow)
-mod_size = (515, 2069)  # slow, fast
-gap_size = (117, 45)  # slow, fast
-image_size = (3043, 4183)  # slow, fast
+MODULE_SIZE = (515, 2069)  # slow, fast
+GAP_SIZE = (117, 45)  # slow, fast
+IMAGE_SIZE_10M = (3043, 4183)  # slow, fast
 
 
 def get_full_file_list(filename_template: str | Path) -> list[Path]:
@@ -58,11 +67,11 @@ def get_full_file_list(filename_template: str | Path) -> list[Path]:
     return file_list
 
 
-def define_modules(det_config: TConfig = "10M") -> dict[str, tuple]:
+def define_modules(det_config: TristanConfig = "10M") -> dict[str, tuple]:
     """Define the start and end pixel of each module in the Tristan detector.
 
     Args:
-        det_config (TConfig, optional): Specify how many physical modules make up the Tristan\
+        det_config (TristanConfig, optional): Specify how many physical modules make up the Tristan\
             detector currently in use. Available configurations: 1M, 2M, 10M.\
             Defaults to "10M".
 
@@ -71,24 +80,23 @@ def define_modules(det_config: TConfig = "10M") -> dict[str, tuple]:
             by a (x,y) tuple. For example a Tristan 1M will return \
             {"0": ([0, 515], [0, 2069])}
     """
-    config_opts = get_args(TConfig)
-    if det_config not in config_opts:
+    if det_config not in TristanConfig.config_opts():
         logger.error(f"Detector configuration {det_config} unknown.")
         raise ValueError(
-            f"Detector configuration unknown. Please pass one of {config_opts}."
+            f"Detector configuration unknown. Please pass one of {TristanConfig.config_opts()}."
         )
-    modules = tristan_config[det_config]
+    modules = TRISTAN_CONFIG[det_config]
     mod = {}
     n = 0
     for _y in range(modules[0]):
         for _x in range(modules[1]):
             int_x = [
-                _x * (mod_size[0] + gap_size[0]),
-                _x * (mod_size[0] + gap_size[0]) + mod_size[0],
+                _x * (MODULE_SIZE[0] + GAP_SIZE[0]),
+                _x * (MODULE_SIZE[0] + GAP_SIZE[0]) + MODULE_SIZE[0],
             ]
             int_y = [
-                _y * (mod_size[1] + gap_size[1]),
-                _y * (mod_size[1] + gap_size[1]) + mod_size[1],
+                _y * (MODULE_SIZE[1] + GAP_SIZE[1]),
+                _y * (MODULE_SIZE[1] + GAP_SIZE[1]) + MODULE_SIZE[1],
             ]
             mod[str(n)] = (int_x, int_y)
             # mod[(_x, _y)] = (int_x, int_y)
@@ -96,11 +104,11 @@ def define_modules(det_config: TConfig = "10M") -> dict[str, tuple]:
     return mod
 
 
-def module_cooordinates(det_config: TConfig = "10M") -> dict[str, tuple]:
+def module_cooordinates(det_config: TristanConfig = "10M") -> dict[str, tuple]:
     """ Create a conversion table between module number and its location on the detector.
 
     Args:
-        det_config(TConfig, optional): Specify how many physical modules make up the Tristan\
+        det_config(TristanConfig, optional): Specify how many physical modules make up the Tristan\
             detector currently in use. Available configurations: 1M, 2M, 10M.\
             Defaults to "10M".
 
@@ -109,13 +117,12 @@ def module_cooordinates(det_config: TConfig = "10M") -> dict[str, tuple]:
         location on the detector. For example a Trisstan 1M will return \
         {"0": (0, 0)}
     """
-    config_opts = get_args(TConfig)
-    if det_config not in config_opts:
+    if det_config not in TristanConfig.config_opts():
         logger.error(f"Detector configuration {det_config} unknown.")
         raise ValueError(
-            f"Detector configuration unknown. Please pass one of {config_opts}."
+            f"Detector configuration unknown. Please pass one of {TristanConfig.config_opts()}."
         )
-    modules = tristan_config[det_config]
+    modules = TRISTAN_CONFIG[det_config]
     table = {}
     n = 0
     for _y in range(modules[0]):
@@ -136,7 +143,9 @@ def _check_for_cues(filename: Path) -> bool:
 
 
 def assign_files_to_modules(
-    filelist: list[Path], det_config: TConfig = "10M", check_for: FileChecker = "events"
+    filelist: list[Path],
+    det_config: TristanConfig = "10M",
+    check_for: FileChecker = "events",
 ):
     """ Assign each file to the correct module after having checked that it has valid events/cues in it.
     While the files should be in order i.e. for module 0 we'll have file numbers 000001-000010, for module 1 \
@@ -145,7 +154,7 @@ def assign_files_to_modules(
 
     Args:
         filelist (list[Path]): List of input tristan files.
-        det_config (TConfig, optional): Specify how many physical modules make up the Tristan \
+        det_config (TristanConfig, optional): Specify how many physical modules make up the Tristan \
             detector currently in use. Available configurations: 1M, 2M, 10M.\
             Defaults to "10M".
         check_for (FileChecker, optional): Specify whether to check for valid events or cues. \

--- a/src/tristan/diagnostics/utils.py
+++ b/src/tristan/diagnostics/utils.py
@@ -24,6 +24,8 @@ logger = logging.getLogger("TristanDiagnostics.Utils")
 TIME_RES = 1.5625e-9  # timing resolution fine
 DIV = np.uint32(0x2000)
 
+FileChecker = Literal["cues", "events"]
+
 # Tristan 10M specs
 TConfig = Literal["1M", "2M", "10M"]
 tristan_config = {"10M": (2, 5), "2M": (1, 2), "1M": (1, 1)}  # (H, V) -.> (fast, slow)
@@ -32,7 +34,7 @@ gap_size = (117, 45)  # slow, fast
 image_size = (3043, 4183)  # slow, fast
 
 
-def get_full_file_list(filename_template: str | Path) -> list(Path):
+def get_full_file_list(filename_template: str | Path) -> list[Path]:
     """Given a template filename, including directory, get a list of all the files\
     using that template.
 
@@ -118,24 +120,67 @@ def module_cooordinates(det_config: TConfig = "10M") -> dict[str, tuple]:
     return table
 
 
-def assign_files_to_modules(filelist: list[Path | str], det_config: TConfig = "10M"):
+def _check_for_cues(filename: Path) -> bool:
+    try:
+        with h5py.File(filename) as fh:
+            _ = fh[cue_id_key][1]
+            _ = fh[cue_time_key][1]
+        return True
+    except IndexError:
+        return False
+
+
+def assign_files_to_modules(
+    filelist: list[Path], det_config: TConfig = "10M", check_for: FileChecker = "events"
+):
+    """ Assign each file to the correct module after having checked that it has valid events/cues in it.
+    While the files should be in order i.e. for module 0 we'll have file numbers 000001-000010, for module 1 \
+    file numbers 000011-000020 and so on, when checking for events an additional check will be done on the \
+    event id when assigning to each module.
+
+    Args:
+        filelist (list[Path]): List of input tristan files.
+        det_config (TConfig, optional): Specify how many physical modules make up the Tristan \
+            detector currently in use. Available configurations: 1M, 2M, 10M.\
+            Defaults to "10M".
+        check_for (FileChecker, optional): Specify whether to check for valid events or cues. \
+            Defaults to "cues".
+
+    Returns:
+        files_per_module(dict[str, list(Path)]): List of files assigned to each module.
+    """
     MOD = define_modules(det_config)
     files_per_module = {k: [] for k in MOD.keys()}
     broken_files = []
-    for filename in filelist:
-        with h5py.File(filename) as fh:
-            try:
-                x, y = divmod(fh[event_location_key][1], DIV)
-                for k, v in MOD.items():
-                    if v[1][0] <= x <= v[1][1]:
-                        if v[0][0] <= y <= v[0][1]:
-                            files_per_module[k].append(filename)
-            except IndexError:
-                broken_files.append(filename)
+    match check_for:
+        case "events":
+            for filename in filelist:
+                try:
+                    with h5py.File(filename) as fh:
+                        x, y = divmod(fh[event_location_key][1], DIV)
+                        # Assign file to correct module depending on coordinates.
+                        # Should be irrelevant as they go in order but still good to check for now
+                        for k, v in MOD.items():
+                            if v[1][0] <= x <= v[1][1]:
+                                if v[0][0] <= y <= v[0][1]:
+                                    files_per_module[k].append(filename)
+                except IndexError:
+                    broken_files.append(filename)
+        case "cues":
+            for filename in filelist:
+                has_cues = _check_for_cues(filename)
+                if has_cues:
+                    # Assign to module based on filename
+                    filenum = int(filename.stem.split("_")[-1]) - 1
+                    mod_num = str(filenum // int(det_config.strip("M")))
+                    files_per_module[mod_num].append(filename)
+                else:
+                    broken_files.append(filename)
     return files_per_module, broken_files
 
 
 def find_shutter_times(filelist):
+    """Find shutter open and close timestamps."""
     sh_open = []
     sh_close = []
     for filename in filelist:

--- a/src/tristan/diagnostics/utils.py
+++ b/src/tristan/diagnostics/utils.py
@@ -167,6 +167,8 @@ def assign_files_to_modules(
                 except IndexError:
                     broken_files.append(filename)
         case "cues":
+            # NOTE This is to check for triggers when dealing with dark field collections which
+            # sometimes have datasets with no events.
             for filename in filelist:
                 has_cues = _check_for_cues(filename)
                 if has_cues:

--- a/src/tristan/diagnostics/utils.py
+++ b/src/tristan/diagnostics/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import glob
 import logging
+from enum import Enum
 from pathlib import Path
 from typing import Literal, get_args
 
@@ -24,7 +25,11 @@ logger = logging.getLogger("TristanDiagnostics.Utils")
 TIME_RES = 1.5625e-9  # timing resolution fine
 DIV = np.uint32(0x2000)
 
-FileChecker = Literal["cues", "events"]
+
+class FileChecker(str, Enum):
+    CUES = "cues"
+    EVENTS = "events"
+
 
 # Tristan 10M specs
 TConfig = Literal["1M", "2M", "10M"]
@@ -153,7 +158,7 @@ def assign_files_to_modules(
     files_per_module = {k: [] for k in MOD.keys()}
     broken_files = []
     match check_for:
-        case "events":
+        case FileChecker.EVENTS:
             for filename in filelist:
                 try:
                     with h5py.File(filename) as fh:
@@ -166,7 +171,7 @@ def assign_files_to_modules(
                                     files_per_module[k].append(filename)
                 except IndexError:
                     broken_files.append(filename)
-        case "cues":
+        case FileChecker.CUES:
             # NOTE This is to check for triggers when dealing with dark field collections which
             # sometimes have datasets with no events.
             for filename in filelist:


### PR DESCRIPTION
The diagnostics tools used for trigger currently doesn't work correctly for dark field datasets. This is because very often some of these collections have files with no events in their datasets, leading to the code flagging these files as broken in all cases. 

This is a workaround that only checks the cues datasets for data and looks at the triggers whether it's dark field data or data collections with beam.