### PR TITLE
Remove the search for a '_meta.h5' file

### DIFF
--- a/src/tristan/command_line/__init__.py
+++ b/src/tristan/command_line/__init__.py
@@ -111,7 +111,7 @@ def check_multiple_output_files(
     unless instructed to overwrite.
 
     Args:
-        quantity:  THe number of output files to be generated.
+        quantity:  The number of output files to be generated.
         out_file:  A suggested output file path.
         stem:  A file name stem to use if out_file is not provided.
         suffix:  A suffix to append to stem when constructing the output file name.
@@ -144,7 +144,7 @@ def check_multiple_output_files(
         return out_files, out_file_pattern
 
 
-def data_files(data_dir: Path, stem: str, n_dig: int = 6) -> (list[Path], Path):
+def data_files(data_dir: Path, stem: str, n_dig: int = 6) -> list[Path]:
     """
     Extract information about the files containing raw cues and events data.
 
@@ -154,15 +154,15 @@ def data_files(data_dir: Path, stem: str, n_dig: int = 6) -> (list[Path], Path):
         n_dig:    Number of digits in the raw file number, e.g. six in '_000001.h5'.
 
     Returns:
-        - Lexicographically sorted list of raw file paths.
-        - File path of the time slice metadata file.
+        A lexicographically sorted list of raw file paths.
     """
-    meta_file = data_dir / f"{stem}_meta.h5"
-    if not meta_file.exists():
-        sys.exit(f"Could not find the expected detector metadata file:\n\t{meta_file}")
-
-    with h5py.File(meta_file) as f:
-        n_files = np.sum(f.get("fp_per_module", default=()))
+    nxs_file = (data_dir / stem).with_suffix(".nxs")
+    if nxs_file.exists():
+        with h5py.File(nxs_file) as f:
+            n_files = sum(f.get("entry/data/meta_file/fp_per_module", default=()))
+    else:
+        print(f"Could not find the expected NeXus file:\n\t{nxs_file}")
+        n_files = 0
 
     if n_files:
         raw_files = [data_dir / f"{stem}_{n + 1:0{n_dig}d}.h5" for n in range(n_files)]
@@ -178,7 +178,7 @@ def data_files(data_dir: Path, stem: str, n_dig: int = 6) -> (list[Path], Path):
         search_path = str(data_dir / f"{stem}_{n_dig * '[0-9]'}.h5")
         raw_files = [Path(path_str) for path_str in sorted(glob.glob(search_path))]
 
-    return raw_files, meta_file
+    return raw_files
 
 
 # A simple version parser.  Print the version and exit.

--- a/src/tristan/command_line/__init__.py
+++ b/src/tristan/command_line/__init__.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import SupportsFloat, SupportsInt
 
 import h5py
-import numpy as np
 import pint.errors
 
 from .. import __version__, ureg

--- a/src/tristan/command_line/cues.py
+++ b/src/tristan/command_line/cues.py
@@ -18,7 +18,7 @@ def main(args=None):
     """Print a human-readable summary of the cue messages in a LATRD data set."""
     args = parser.parse_args(args)
 
-    raw_files, _ = data_files(args.data_dir, args.stem)
+    raw_files = data_files(args.data_dir, args.stem)
 
     with latrd_data(raw_files, keys=cue_keys) as data:
         relevant = (data.cue_id > 0) & (data.cue_id != reserved)

--- a/src/tristan/command_line/images.py
+++ b/src/tristan/command_line/images.py
@@ -134,7 +134,7 @@ def single_image_cli(args):
 
     image_size = args.image_size or determine_image_size(input_nexus)
 
-    raw_files, _ = data_files(args.data_dir, args.stem)
+    raw_files = data_files(args.data_dir, args.stem)
 
     print("Finding detector shutter open and close times.")
     with latrd_data(raw_files, keys=cue_keys) as data, ProgressBar():
@@ -179,7 +179,7 @@ def multiple_images_cli(args):
 
     image_size = args.image_size or determine_image_size(input_nexus)
 
-    raw_files, _ = data_files(args.data_dir, args.stem)
+    raw_files = data_files(args.data_dir, args.stem)
 
     with latrd_data(raw_files, keys=cue_keys) as data:
         print("Finding detector shutter open and close times.")
@@ -285,7 +285,7 @@ def pump_probe_cli(args):
 
     image_size = args.image_size or determine_image_size(input_nexus)
 
-    raw_files, _ = data_files(args.data_dir, args.stem)
+    raw_files = data_files(args.data_dir, args.stem)
 
     trigger_type = triggers.get(args.trigger_type)
 
@@ -383,7 +383,7 @@ def multiple_sequences_cli(args):
 
     image_size = args.image_size or determine_image_size(input_nexus)
 
-    raw_files, _ = data_files(args.data_dir, args.stem)
+    raw_files = data_files(args.data_dir, args.stem)
 
     trigger_type = triggers.get(args.trigger_type)
 
@@ -549,7 +549,7 @@ def gated_images_cli(args):
 
     image_size = args.image_size or determine_image_size(input_nexus)
 
-    raw_files, _ = data_files(args.data_dir, args.stem)
+    raw_files = data_files(args.data_dir, args.stem)
 
     # If gate_close isn't specified, default to the complementary signal to gate_open.
     gate_open = triggers.get(args.gate_open)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -45,29 +45,27 @@ def test_data_files(dummy_data_transient):
     """Test the utility for discovering Tristan data file paths."""
     # Expected file paths.
     stem = "dummy"
-    meta_file = dummy_data_transient / f"{stem}_meta.h5"
+    nxs_file = (dummy_data_transient / stem).with_suffix(".nxs")
     raw_files = sorted(dummy_data_transient.iterdir())
 
-    # Check that the absence of the metadata file raises an error.
-    with pytest.raises(
-        SystemExit, match="Could not find the expected detector metadata file:"
-    ):
-        data_files(dummy_data_transient, stem)
+    # Check that the absence of the NeXus file results in correct inference of the
+    # number of raw data files.
+    assert data_files(dummy_data_transient, stem) == raw_files
 
-    # Check that a metadata file with a valid (or missing) frame-processors-per-module
+    # Check that a NeXus file with a valid (or missing) frame-processors-per-module
     # metadatum results in the correct file paths being determined.
     for fp_per_module in ((), (1, 1, 1), (3,)):
-        with h5py.File(meta_file, "w") as f:
-            f["fp_per_module"] = fp_per_module
+        with h5py.File(nxs_file, "w") as f:
+            f["entry/data/meta_file/fp_per_module"] = fp_per_module
 
-        assert data_files(dummy_data_transient, stem) == (raw_files, meta_file)
+        assert data_files(dummy_data_transient, stem) == raw_files
 
     # Check that missing raw files, as determined from the fp-per-module metadatum,
     # raise an error.
     fp_per_module = (4,)
     missing_file = f"{dummy_data_transient / stem}_000004.h5"
-    with h5py.File(meta_file, "w") as f:
-        f["fp_per_module"] = fp_per_module
+    with h5py.File(nxs_file, "w") as f:
+        f["entry/data/meta_file/fp_per_module"] = fp_per_module
     with pytest.raises(
         SystemExit,
         match=f"The following expected data files are missing:\n\t{missing_file}",


### PR DESCRIPTION
The file in question is now accessible from the '.nxs' file as an external link, meaning that there is no need for this rather fragile heuristic of deducing the expected '_meta.h5' file path.