### PR TITLE
Pin nexgen 0.9.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     dask[array,diagnostics,distributed]!=2021.3.*,<2023.4
     h5py>=3.8
     hdf5plugin>=4.0.1
-    nexgen>=0.9.1
+    nexgen>=0.9.3
     numpy<2.0
     pandas
     pint


### PR DESCRIPTION
nexgen `0.9.3` has a change that writes a nexus file a little closer to NXmx standard, which had to include some breaking fixes to the copy tools for python-tristan