### PR TITLE
Guard against haunted netCDF4/HDF5 combo

### DIFF
--- a/src/tristan/command_line/__init__.py
+++ b/src/tristan/command_line/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import argparse
 import glob
 import re

--- a/src/tristan/command_line/apply_flat_field.py
+++ b/src/tristan/command_line/apply_flat_field.py
@@ -4,6 +4,11 @@
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import argparse
 import pathlib
 import shutil

--- a/src/tristan/command_line/images/__init__.py
+++ b/src/tristan/command_line/images/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import sys
 from pathlib import Path
 

--- a/src/tristan/command_line/images/gated_images_cli.py
+++ b/src/tristan/command_line/images/gated_images_cli.py
@@ -8,6 +8,11 @@ signal is taken as the end of the exposure.
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import sys
 
 import h5py

--- a/src/tristan/command_line/images/multiple_images_cli.py
+++ b/src/tristan/command_line/images/multiple_images_cli.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import sys
 
 import h5py

--- a/src/tristan/command_line/images/multiple_sequences_cli.py
+++ b/src/tristan/command_line/images/multiple_sequences_cli.py
@@ -11,6 +11,11 @@ numbered from the shortest pump-probe delay to the longest.
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import sys
 from contextlib import ExitStack
 from pathlib import Path

--- a/src/tristan/command_line/images/pump_probe_cli.py
+++ b/src/tristan/command_line/images/pump_probe_cli.py
@@ -8,6 +8,11 @@ delay times, from shortest to longest.
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import sys
 
 import h5py

--- a/src/tristan/command_line/images/single_image_cli.py
+++ b/src/tristan/command_line/images/single_image_cli.py
@@ -4,6 +4,11 @@ Aggregate all the events from a LATRD Tristan data collection into a single imag
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import sys
 from operator import mul
 

--- a/src/tristan/diagnostics/check_valid_events.py
+++ b/src/tristan/diagnostics/check_valid_events.py
@@ -4,6 +4,11 @@ Run a quick check to diagnose possible asynchronicity between the shutter timest
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import argparse
 import logging
 import multiprocessing as mp

--- a/src/tristan/diagnostics/find_trigger_intervals.py
+++ b/src/tristan/diagnostics/find_trigger_intervals.py
@@ -4,6 +4,11 @@ Run a quick check on trigger signals recorded in a Tristan collection.
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import argparse
 import logging
 import multiprocessing as mp

--- a/src/tristan/diagnostics/utils.py
+++ b/src/tristan/diagnostics/utils.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+# Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
+# '/path/to/HDF5/file.h5'
+# Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
+import netCDF4  # noqa F401
+
 import glob
 import logging
 from enum import Enum

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 # Some platforms seem to raise OSError: [Errno -101] NetCDF: HDF error:
-# '/tmp/pytest-of-vsts/pytest-0/dummy_data1/dummy_000001.h5'
+# '/path/to/HDF5/file.h5'
 # Importing netCDF4 before h5py here seems to fix it.  ¯\_(ツ)_/¯
-from netCDF4 import Dataset  # noqa F401
+import netCDF4  # noqa F401
 
 import os
 from contextlib import contextmanager


### PR DESCRIPTION
On some platforms, it seems importing `h5py` before `netCDF4` leads to errors like
```
OSError: [Errno -101] NetCDF: HDF error: '/path/to/HDF5/file.h5'
```
when trying to open an HDF5 file as an Xarray dataset.

This might be fixed by proper packaging, since it seems to happen when Pip installs incompatible `h5py` and `netCDF4` packages (motivation for CondaForge feedstock, perhaps), but for now [the generally accepted workaround](https://github.com/Unidata/netcdf4-python/issues/653#issuecomment-592241778) seems just to be importing `netCDF4` first.