### PR TITLE
Explicit Dask Dataframe dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project-urls =
 [options]
 include_package_data = True
 install_requires =
-    dask[array,diagnostics,distributed]!=2021.3.*
+    dask[array,dataframe,diagnostics,distributed]!=2021.3.*
     h5py>=3.8
     hdf5plugin>=4.0.1
     netcdf4


### PR DESCRIPTION
Explicitly state `dask[dataframe]` as a dependency to avoid this `FutureWarning`:
```
/<Python-environment>/site-packages/dask/dataframe/__init__.py:42: FutureWarning: 
Dask dataframe query planning is disabled because dask-expr is not installed.

You can install it with `pip install dask[dataframe]` or `conda install dask`.
This will raise in a future version.

  warnings.warn(msg, FutureWarning)
```